### PR TITLE
Switch to ValidationError

### DIFF
--- a/worf/tests/validators_tests.py
+++ b/worf/tests/validators_tests.py
@@ -1,9 +1,9 @@
 import pytest
 from uuid import UUID
 
+from django.core.exceptions import ValidationError
 from django.test import RequestFactory
 
-from worf.exceptions import HTTP422
 from worf.validators import ValidationMixin
 from worf.views import AbstractBaseAPI
 from django.db import models
@@ -22,7 +22,7 @@ class DummyAPI(ValidationMixin):
         try:
             assert value == "(555) 555-5555"
         except AssertionError:
-            raise HTTP422("{value} is not a valid phone number")
+            raise ValidationError("{value} is not a valid phone number")
         return "+5555555555"
 
 
@@ -50,9 +50,9 @@ def test_validate_uuid_passes(view):
     assert result == UUID(string)
 
 
-def test_validate_uuid_raises_http422(view):
+def test_validate_uuid_raises_error(view):
     string = "not-a-uuid"
-    with pytest.raises(HTTP422):
+    with pytest.raises(ValidationError):
         view.validate_uuid(string)
 
 
@@ -62,9 +62,9 @@ def test_validate_email_passes(view):
     assert email == result
 
 
-def test_validate_email_raises_http422(view):
+def test_validate_email_raises_error(view):
     email = "fake.example@com"
-    with pytest.raises(HTTP422):
+    with pytest.raises(ValidationError):
         view.validate_email(email)
 
 
@@ -73,9 +73,9 @@ def test_validate_custom_field_passes(view):
     assert view.validate_phone(phone) == "+5555555555"
 
 
-def test_validate_custom_field_raises_http422(view):
+def test_validate_custom_field_raises_error(view):
     phone = "invalid number"
-    with pytest.raises(HTTP422):
+    with pytest.raises(ValidationError):
         view.validate_phone(phone)
 
 


### PR DESCRIPTION
This is mostly to support #11 so that custom validation rules outside of worf can raise `ValidationError` and get the expected behavior, and by extension I figured the built-ins should use it too.

I also added an `ObjectDoesNotExist` catch, the assumption being that a 404 is a better thing to serve if this code path is ever hit than a 500, and that there's probably a use case for it, but I don't have one right now.

Note that http exceptions continue to be supported, this just adds support for raising core exceptions without needing to wrap them in catches that translate them to http exceptions. Validation methods shouldn't need to care about HTTP.