### PR TITLE
Serializer

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,7 @@ def pytest_configure():
             "django.contrib.auth.middleware.AuthenticationMiddleware",
             "django.contrib.messages.middleware.MessageMiddleware",
         ],
-        ROOT_URLCONF="test.urls",
+        ROOT_URLCONF="tests.urls",
         DATABASES={
             "default": {
                 "ENGINE": "django.db.backends.sqlite3",

--- a/tests/models.py
+++ b/tests/models.py
@@ -7,11 +7,7 @@ class DummyModel(models.Model):
     phone = models.CharField(max_length=64)
 
     def api(self):
-        return dict(
-            id=self.id,
-            email=self.email,
-            phone=self.phone
-        )
+        return dict(id=self.id, email=self.email, phone=self.phone)
 
     def api_update_fields(self):
         return [

--- a/tests/serializer_tests.py
+++ b/tests/serializer_tests.py
@@ -8,7 +8,9 @@ def test_user_get(client, django_user_model):
     assert deserialize(response)["username"] == "test"
 
     bundle = dict(username="testtest", email="something@example.com")
-    response = client.patch("/user/{}/".format(user.pk), bundle, content_type="application/json")
+    response = client.patch(
+        "/user/{}/".format(user.pk), bundle, content_type="application/json"
+    )
     assert response.status_code == 200
     assert deserialize(response)["username"] == "testtest"
     assert deserialize(response)["email"] == "something@example.com"

--- a/tests/serializer_tests.py
+++ b/tests/serializer_tests.py
@@ -6,3 +6,9 @@ def test_user_get(client, django_user_model):
     response = client.get("/user/{}/".format(user.pk))
     assert response.status_code == 200
     assert deserialize(response)["username"] == "test"
+
+    bundle = dict(username="testtest", email="something@example.com")
+    response = client.patch("/user/{}/".format(user.pk), bundle, content_type="application/json")
+    assert response.status_code == 200
+    assert deserialize(response)["username"] == "testtest"
+    assert deserialize(response)["email"] == "something@example.com"

--- a/tests/serializer_tests.py
+++ b/tests/serializer_tests.py
@@ -1,0 +1,8 @@
+from worf.testing import deserialize
+
+
+def test_user_get(client, django_user_model):
+    user = django_user_model.objects.create_user(username="test", password="password")
+    response = client.get("/user/{}/".format(user.pk))
+    assert response.status_code == 200
+    assert deserialize(response)["username"] == "test"

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,8 +1,9 @@
 from django.urls import include, path
 
-from tests.views import DummyAPI
+from tests.views import DummyAPI, UserAPI
 
 urlpatterns = [
     path("", DummyAPI.as_view()),
     path("<str:id>/", DummyAPI.as_view()),
+    path("user/<str:id>/", UserAPI.as_view()),
 ]

--- a/tests/views.py
+++ b/tests/views.py
@@ -1,12 +1,16 @@
 from django.core.exceptions import ValidationError
+from django.contrib.auth.models import User
 
-from tests.models import DummyModel
-from worf.validators import ValidationMixin
+from worf.permissions import PublicEndpoint
+from worf.serializers import Serializer
 from worf.views import DetailUpdateAPI
 
+from tests.models import DummyModel
 
-class DummyAPI(DetailUpdateAPI, ValidationMixin):
+
+class DummyAPI(DetailUpdateAPI):
     model = DummyModel
+    permissions = [PublicEndpoint]
 
     def validate_phone(self, value):
         try:
@@ -14,3 +18,26 @@ class DummyAPI(DetailUpdateAPI, ValidationMixin):
         except AssertionError:
             raise ValidationError("{value} is not a valid phone number")
         return "+5555555555"
+
+
+class UserSerializer(Serializer):
+
+    def write(self):
+        return [
+            "username",
+            "email",
+        ]
+
+    def read(self):
+        return dict(
+            username=self.model.username,
+            lastLogin=self.model.last_login,
+            dateJoined=self.model.date_joined,
+            email=self.model.email,
+        )
+
+
+class UserAPI(DetailUpdateAPI):
+    model = User
+    serializer = UserSerializer
+    permissions = [PublicEndpoint]

--- a/tests/views.py
+++ b/tests/views.py
@@ -21,7 +21,6 @@ class DummyAPI(DetailUpdateAPI):
 
 
 class UserSerializer(Serializer):
-
     @classmethod
     def write(cls):
         return [

--- a/tests/views.py
+++ b/tests/views.py
@@ -22,7 +22,8 @@ class DummyAPI(DetailUpdateAPI):
 
 class UserSerializer(Serializer):
 
-    def write(self):
+    @classmethod
+    def write(cls):
         return [
             "username",
             "email",

--- a/worf/serializers.py
+++ b/worf/serializers.py
@@ -1,0 +1,13 @@
+class Serializer:
+    def __init__(self, model, *args, **kwargs):
+        self.model = model
+        super().__init__()
+
+    def read(self):
+        return dict()
+
+    def write(self):
+        return []
+
+    def create(self):
+        return []

--- a/worf/serializers.py
+++ b/worf/serializers.py
@@ -3,11 +3,14 @@ class Serializer:
         self.model = model
         super().__init__()
 
+    # todo add validation that fields in these methods are actually on the model
+
     def read(self):
         return dict()
 
     def write(self):
         return []
 
-    def create(self):
+    @classmethod
+    def create(cls):
         return []

--- a/worf/serializers.py
+++ b/worf/serializers.py
@@ -8,7 +8,8 @@ class Serializer:
     def read(self):
         return dict()
 
-    def write(self):
+    @classmethod
+    def write(cls):
         return []
 
     @classmethod

--- a/worf/validators.py
+++ b/worf/validators.py
@@ -122,7 +122,7 @@ class ValidationMixin:
         @param key _str_ the model attribute to check against.
         @return value:
             - If the HTTP method is not PATCH and `key` does not exist in the
-        model api_update_fields method, return False.
+        model serializer method, return False.
             - If an error is detected, HTTP400 or ValidationError will be raised
             - If all checks pass, True is returned
 
@@ -136,11 +136,11 @@ class ValidationMixin:
         # self.request.method == 'POST' or
         if (
             self.request.method == "PATCH" or self.request.method == "PUT"
-        ) and key not in self.api_update_fields():
+        ) and key not in self.get_serializer():
             err_msg = f"{snake_to_camel(key)} is not editable"
             if settings.DEBUG:
                 err_msg += f":: {self.codepath}.{self.api_update_field_method_name()}"
-                err_msg += f":: {self.api_update_fields()}"
+                err_msg += f":: {self.get_serializer()}"
             raise ValidationError(err_msg)
 
         if not hasattr(self.model, key):

--- a/worf/views/__init__.py
+++ b/worf/views/__init__.py
@@ -11,3 +11,4 @@ from worf.views.base import (
     APIResponse,
     AbstractBaseAPI,
 )
+from worf.views.create import CreateAPI

--- a/worf/views/base.py
+++ b/worf/views/base.py
@@ -55,6 +55,7 @@ class AbstractBaseAPI(APIResponse, ValidationMixin):
     model = None
     permissions = []
     api_method = "api"
+    serializer = None
     payload_key = None
 
     def __init__(self, *args, **kwargs):

--- a/worf/views/base.py
+++ b/worf/views/base.py
@@ -220,7 +220,3 @@ class AbstractBaseAPI(APIResponse, ValidationMixin):
             )
         except ValidationError as e:
             return self.render_to_response(dict(message=e.message), HTTP422.status)
-
-    def get(self, request, *args, **kwargs):
-        """Get is always implicitly available on every endpoint."""
-        return self.render_to_response()

--- a/worf/views/create.py
+++ b/worf/views/create.py
@@ -5,7 +5,6 @@ from worf.views.base import AbstractBaseAPI
 
 
 class CreateAPI(AbstractBaseAPI):
-
     def post(self, request, *args, **kwargs):
 
         # Deprecate ------------------------------------------------------------

--- a/worf/views/create.py
+++ b/worf/views/create.py
@@ -5,6 +5,9 @@ from worf.views.base import AbstractBaseAPI
 
 
 class CreateAPI(AbstractBaseAPI):
+    def serialize(self):
+        return {}
+
     def post(self, request, *args, **kwargs):
 
         # Deprecate ------------------------------------------------------------
@@ -20,6 +23,7 @@ class CreateAPI(AbstractBaseAPI):
 
         for key in self.bundle.keys():
             self.validate_bundle(key)
+            # this should be moved into validate bundle
             if key not in self.serializer.create():
                 raise ValidationError(
                     "{} not allowed when creating {}".format(
@@ -27,9 +31,5 @@ class CreateAPI(AbstractBaseAPI):
                     )
                 )
 
-        if set(self.bundle.keys()) != set(self.serializer.create()):
-            raise ValidationError(
-                "{} are required to create {}".format(
-                    [snake_to_camel(key) for key in self.serializer.create()], self.name
-                )
-            )
+        new_instance = self.model.objects.create(**self.bundle)
+        return self.render_to_response(self.serializer(new_instance).read(), 201)

--- a/worf/views/create.py
+++ b/worf/views/create.py
@@ -1,0 +1,36 @@
+from django.core.exceptions import ValidationError
+
+from worf.casing import snake_to_camel
+from worf.views.base import AbstractBaseAPI
+
+
+class CreateAPI(AbstractBaseAPI):
+
+    def post(self, request, *args, **kwargs):
+
+        # Deprecate ------------------------------------------------------------
+        if self.serializer is None:
+            for key in self.bundle.keys():
+                self.validate_bundle(key)
+
+            new_instance = self.model.objects.create(**self.bundle)
+            return self.render_to_response(
+                getattr(new_instance, self.api_method)(), 201
+            )
+        # ------------------------------------------------------------ Deprecate
+
+        for key in self.bundle.keys():
+            self.validate_bundle(key)
+            if key not in self.serializer.create():
+                raise ValidationError(
+                    "{} not allowed when creating {}".format(
+                        snake_to_camel(key), self.name
+                    )
+                )
+
+        if set(self.bundle.keys()) != set(self.serializer.create()):
+            raise ValidationError(
+                "{} are required to create {}".format(
+                    [snake_to_camel(key) for key in self.serializer.create()], self.name
+                )
+            )

--- a/worf/views/detail.py
+++ b/worf/views/detail.py
@@ -5,6 +5,9 @@ from worf.shortcuts import get_instance_or_http404
 
 
 class ChoicesFieldOptionsAPI(AbstractBaseAPI):
+    def get(self, request, *args, **kwargs):
+        return self.render_to_response()
+
     def serialize(self):
         return getattr(self.model, self.api_method)()
 
@@ -13,6 +16,9 @@ class DetailAPI(AbstractBaseAPI):
     lookup_field = "id"
     lookup_url_kwarg = "id"
     instance = None
+
+    def get(self, request, *args, **kwargs):
+        return self.render_to_response()
 
     @classmethod
     def api_update_field_method_name(cls):

--- a/worf/views/detail.py
+++ b/worf/views/detail.py
@@ -24,7 +24,7 @@ class DetailAPI(AbstractBaseAPI):
     def api_update_field_method_name(cls):
         return f"{cls.api_method}_update_fields"
 
-    def api_update_fields(self):
+    def get_serializer(self):
         """Return the model api_update_fields, used for update."""
         if self.serializer is not None:
             return self.serializer.write()

--- a/worf/views/detail.py
+++ b/worf/views/detail.py
@@ -26,6 +26,8 @@ class DetailAPI(AbstractBaseAPI):
 
     def api_update_fields(self):
         """Return the model api_update_fields, used for update."""
+        if self.serializer is not None:
+            return self.serializer.write()
         return getattr(self.get_instance(), self.api_update_field_method_name())()
 
     def serialize(self):

--- a/worf/views/detail.py
+++ b/worf/views/detail.py
@@ -1,6 +1,5 @@
 from django.core.exceptions import ImproperlyConfigured
 
-from worf.exceptions import HTTP404
 from worf.views.base import AbstractBaseAPI
 from worf.shortcuts import get_instance_or_http404
 
@@ -25,11 +24,16 @@ class DetailAPI(AbstractBaseAPI):
 
     def serialize(self):
         """Return the model api, used for responses."""
-        payload = getattr(self.get_instance(), self.api_method)()
-        if not isinstance(payload, dict):
-            msg = (
-                f"{self.model.__name__}.{self.api_method}() did not return a dictionary"
+        if self.serializer is not None:
+            payload = self.serializer(self.get_instance()).read()
+            msg = "{} did not return a dictionary".format(self.serializer)
+        else:
+            payload = getattr(self.get_instance(), self.api_method)()
+            msg = "{}.{}() did not return a dictionary".format(
+                self.model.__name__, self.api_method
             )
+
+        if not isinstance(payload, dict):
             raise ImproperlyConfigured(msg)
         return payload
 

--- a/worf/views/detail.py
+++ b/worf/views/detail.py
@@ -24,14 +24,17 @@ class DetailAPI(AbstractBaseAPI):
 
     def serialize(self):
         """Return the model api, used for responses."""
-        if self.serializer is not None:
-            payload = self.serializer(self.get_instance()).read()
-            msg = "{} did not return a dictionary".format(self.serializer)
-        else:
+
+        # Deprecate ------------------------------------------------------------
+        if self.serializer is None:
             payload = getattr(self.get_instance(), self.api_method)()
             msg = "{}.{}() did not return a dictionary".format(
                 self.model.__name__, self.api_method
             )
+        # ------------------------------------------------------------ Deprecate
+        else:
+            payload = self.serializer(self.get_instance()).read()
+            msg = "{} did not return a dictionary".format(self.serializer)
 
         if not isinstance(payload, dict):
             raise ImproperlyConfigured(msg)

--- a/worf/views/list.py
+++ b/worf/views/list.py
@@ -4,6 +4,7 @@ from django.core.paginator import Paginator, EmptyPage
 from django.db.models import Q
 
 from worf.views.base import AbstractBaseAPI
+from worf.views.create import CreateAPI
 from worf.exceptions import HTTP420
 
 
@@ -145,6 +146,7 @@ class ListAPI(AbstractBaseAPI):
 
     def serialize(self):
 
+        # Deprecate ------------------------------------------------------------
         if self.serializer is None:
             payload = {
                 str(self.name): [
@@ -152,6 +154,7 @@ class ListAPI(AbstractBaseAPI):
                     for instance in self.paginated_results()
                 ],
             }
+        # ------------------------------------------------------------ Deprecate
         else:
             payload = {
                 str(self.name): [
@@ -186,6 +189,7 @@ class ListAPI(AbstractBaseAPI):
                     "lookup_kwargs": self.lookup_kwargs,
                     "query": self.query,
                     "q_objs": str(self.q_objects),
+                    "serializer": self.serializer,
                 }
             }
         )
@@ -193,11 +197,5 @@ class ListAPI(AbstractBaseAPI):
         return payload
 
 
-class ListCreateAPI(ListAPI):
-    def post(self, request, *args, **kwargs):
-        for key in self.bundle.keys():
-            self.validate_bundle(key)
-
-        new_instance = self.model.objects.create(**self.bundle)
-        # TODO except certain errors
-        return self.render_to_response(getattr(new_instance, self.api_method)(), 201)
+class ListCreateAPI(CreateAPI, ListAPI):
+    pass

--- a/worf/views/list.py
+++ b/worf/views/list.py
@@ -19,6 +19,9 @@ class ListAPI(AbstractBaseAPI):
     page_num = 1
     num_pages = 1
 
+    def get(self, request, *args, **kwargs):
+        return self.render_to_response()
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if not isinstance(self.filters, dict):

--- a/worf/views/list.py
+++ b/worf/views/list.py
@@ -200,5 +200,5 @@ class ListAPI(AbstractBaseAPI):
         return payload
 
 
-class ListCreateAPI(CreateAPI, ListAPI):
+class ListCreateAPI(ListAPI, CreateAPI):
     pass


### PR DESCRIPTION
This allows a class-based serializer to be used in place of the `api_method` pattern. 

Still WIP, this serializer won't entirely work in certain scenarios (We still count on `update_fields` outside of the `CreateAPI`

I considered using marshmallow for serializer, but so much of what the `validators` is doing is using the django model to perform serialization in the correct way. I don't see a need to redefine that a model field is a character field or an integer field again inside the serializer. 

The single worf.serializers.Serializer is simple, it merely combines the `api_method`, `api_update_fields` and adds an additional method for `create` These become `read()` `write()` and `create()`. Read returns a dictionary, which allows for mapping the fields from the model the same way we do currently with the `api_method`. 

I do like this approach better because it allows for much cleaner understanding of the serializers, especially when you have several of them on a particular model. 