### PR TITLE
Switch to instance-based serializers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def read(rel_path):
 def get_version(rel_path):
     # type: (str) -> str
     for line in read(rel_path).splitlines():
-        if line.startswith('__version__'):
+        if line.startswith("__version__"):
             # __version__ = "0.9"
             delim = '"' if '"' in line else "'"
             return line.split(delim)[1]

--- a/tests/views.py
+++ b/tests/views.py
@@ -21,20 +21,19 @@ class DummyAPI(DetailUpdateAPI):
 
 
 class UserSerializer(Serializer):
-    @classmethod
-    def write(cls):
+    def read(self, model):
+        return dict(
+            username=model.username,
+            lastLogin=model.last_login,
+            dateJoined=model.date_joined,
+            email=model.email,
+        )
+
+    def write(self):
         return [
             "username",
             "email",
         ]
-
-    def read(self):
-        return dict(
-            username=self.model.username,
-            lastLogin=self.model.last_login,
-            dateJoined=self.model.date_joined,
-            email=self.model.email,
-        )
 
 
 class UserAPI(DetailUpdateAPI):

--- a/worf/serializers.py
+++ b/worf/serializers.py
@@ -1,17 +1,25 @@
 class Serializer:
-    def __init__(self, model, *args, **kwargs):
-        self.model = model
-        super().__init__()
-
-    # todo add validation that fields in these methods are actually on the model
-
-    def read(self):
-        return dict()
-
-    @classmethod
-    def write(cls):
+    def create(self):
         return []
 
-    @classmethod
-    def create(cls):
+    def read(self, model):
+        return {}
+
+    def write(self):
         return []
+
+
+class LegacySerializer(Serializer):
+    def __init__(self, model_class, api_method):
+        self.api_method = api_method
+        self.model_class = model_class
+
+    def read(self, model):
+        payload = getattr(model, self.api_method)()
+        if not isinstance(payload, dict):
+            msg = f"{model.__name__}.{self.api_method}() did not return a dictionary"
+            raise ImproperlyConfigured(msg)
+        return payload
+
+    def write(self):
+        return getattr(self.model_class(), f"{self.api_method}_update_fields")()

--- a/worf/testing.py
+++ b/worf/testing.py
@@ -21,7 +21,7 @@ def generate_endpoint_tests(TestCase, API, instance, uri, patch=False, overrides
     """
 
     bundle = {
-        **bundle_factory(instance, API.api_update_field_method_name()),
+        **bundle_factory(instance, f"{API.api_method}_update_fields"),
         **overrides,
     }
     response = TestCase.client.get(uri)

--- a/worf/validators.py
+++ b/worf/validators.py
@@ -134,13 +134,11 @@ class ValidationMixin:
         """
         # POST cannot validate b/c it allows fields not in api_update_fields
         # self.request.method == 'POST' or
-        if (
-            self.request.method == "PATCH" or self.request.method == "PUT"
-        ) and key not in self.get_serializer():
+        serializer = self.get_serializer()
+        if self.request.method in ("PATCH", "PUT") and key not in serializer.write():
             err_msg = f"{snake_to_camel(key)} is not editable"
             if settings.DEBUG:
-                err_msg += f":: {self.codepath}.{self.api_update_field_method_name()}"
-                err_msg += f":: {self.get_serializer()}"
+                err_msg += f":: {serializer}"
             raise ValidationError(err_msg)
 
         if not hasattr(self.model, key):

--- a/worf/views/base.py
+++ b/worf/views/base.py
@@ -155,6 +155,9 @@ class AbstractBaseAPI(APIResponse, ValidationMixin):
 
         return self.model._meta.get_field(field).get_internal_type()
 
+    def get_serializer(self):
+        return self.serializer
+
     def validate_lookup_field_values(self):
         # todo check for each lookup kwarg
         for field, url_kwarg in self.lookup_kwargs.items():

--- a/worf/views/create.py
+++ b/worf/views/create.py
@@ -11,21 +11,12 @@ class CreateAPI(AbstractBaseAPI):
     def post(self, request, *args, **kwargs):
         serializer = self.get_serializer()
 
-        # Deprecate ------------------------------------------------------------
-        if serializer is None:
-            for key in self.bundle.keys():
-                self.validate_bundle(key)
-
-            new_instance = self.model.objects.create(**self.bundle)
-            return self.render_to_response(
-                getattr(new_instance, self.api_method)(), 201
-            )
-        # ------------------------------------------------------------ Deprecate
-
+        create_fields = serializer.create()
         for key in self.bundle.keys():
             self.validate_bundle(key)
+            # ignore create_fields for now if it's empty
             # this should be moved into validate bundle
-            if key not in serializer.create():
+            if create_fields and key not in create_fields:
                 raise ValidationError(
                     "{} not allowed when creating {}".format(
                         snake_to_camel(key), self.name
@@ -33,4 +24,4 @@ class CreateAPI(AbstractBaseAPI):
                 )
 
         new_instance = self.model.objects.create(**self.bundle)
-        return self.render_to_response(serializer(new_instance).read(), 201)
+        return self.render_to_response(serializer.read(new_instance), 201)

--- a/worf/views/create.py
+++ b/worf/views/create.py
@@ -9,9 +9,10 @@ class CreateAPI(AbstractBaseAPI):
         return {}
 
     def post(self, request, *args, **kwargs):
+        serializer = self.get_serializer()
 
         # Deprecate ------------------------------------------------------------
-        if self.serializer is None:
+        if serializer is None:
             for key in self.bundle.keys():
                 self.validate_bundle(key)
 
@@ -24,7 +25,7 @@ class CreateAPI(AbstractBaseAPI):
         for key in self.bundle.keys():
             self.validate_bundle(key)
             # this should be moved into validate bundle
-            if key not in self.serializer.create():
+            if key not in serializer.create():
                 raise ValidationError(
                     "{} not allowed when creating {}".format(
                         snake_to_camel(key), self.name
@@ -32,4 +33,4 @@ class CreateAPI(AbstractBaseAPI):
                 )
 
         new_instance = self.model.objects.create(**self.bundle)
-        return self.render_to_response(self.serializer(new_instance).read(), 201)
+        return self.render_to_response(serializer(new_instance).read(), 201)

--- a/worf/views/detail.py
+++ b/worf/views/detail.py
@@ -20,34 +20,12 @@ class DetailAPI(AbstractBaseAPI):
     def get(self, request, *args, **kwargs):
         return self.render_to_response()
 
-    @classmethod
-    def api_update_field_method_name(cls):
-        return f"{cls.api_method}_update_fields"
-
-    def get_serializer(self):
-        """Return the model api_update_fields, used for update."""
-        serializer = super().get_serializer()
-        if serializer is not None:
-            return serializer.write()
-        return getattr(self.get_instance(), self.api_update_field_method_name())()
-
     def serialize(self):
         """Return the model api, used for responses."""
         serializer = self.get_serializer()
-
-        # Deprecate ------------------------------------------------------------
-        if serializer is None:
-            payload = getattr(self.get_instance(), self.api_method)()
-            msg = "{}.{}() did not return a dictionary".format(
-                self.model.__name__, self.api_method
-            )
-        # ------------------------------------------------------------ Deprecate
-        else:
-            payload = serializer(self.get_instance()).read()
-            msg = "{} did not return a dictionary".format(serializer)
-
+        payload = serializer.read(self.get_instance())
         if not isinstance(payload, dict):
-            raise ImproperlyConfigured(msg)
+            raise ImproperlyConfigured(f"{serializer} did not return a dictionary")
         return payload
 
     def get_instance(self):

--- a/worf/views/detail.py
+++ b/worf/views/detail.py
@@ -26,23 +26,25 @@ class DetailAPI(AbstractBaseAPI):
 
     def get_serializer(self):
         """Return the model api_update_fields, used for update."""
-        if self.serializer is not None:
-            return self.serializer.write()
+        serializer = super().get_serializer()
+        if serializer is not None:
+            return serializer.write()
         return getattr(self.get_instance(), self.api_update_field_method_name())()
 
     def serialize(self):
         """Return the model api, used for responses."""
+        serializer = self.get_serializer()
 
         # Deprecate ------------------------------------------------------------
-        if self.serializer is None:
+        if serializer is None:
             payload = getattr(self.get_instance(), self.api_method)()
             msg = "{}.{}() did not return a dictionary".format(
                 self.model.__name__, self.api_method
             )
         # ------------------------------------------------------------ Deprecate
         else:
-            payload = self.serializer(self.get_instance()).read()
-            msg = "{} did not return a dictionary".format(self.serializer)
+            payload = serializer(self.get_instance()).read()
+            msg = "{} did not return a dictionary".format(serializer)
 
         if not isinstance(payload, dict):
             raise ImproperlyConfigured(msg)

--- a/worf/views/list.py
+++ b/worf/views/list.py
@@ -150,21 +150,11 @@ class ListAPI(AbstractBaseAPI):
     def serialize(self):
         serializer = self.get_serializer()
 
-        # Deprecate ------------------------------------------------------------
-        if serializer is None:
-            payload = {
-                str(self.name): [
-                    getattr(instance, self.api_method)()
-                    for instance in self.paginated_results()
-                ],
-            }
-        # ------------------------------------------------------------ Deprecate
-        else:
-            payload = {
-                str(self.name): [
-                    serializer(instance).read() for instance in self.paginated_results
-                ]
-            }
+        payload = {
+            str(self.name): [
+                serializer.read(instance) for instance in self.paginated_results()
+            ]
+        }
 
         if self.results_per_page:
             payload.update(
@@ -192,7 +182,7 @@ class ListAPI(AbstractBaseAPI):
                     "lookup_kwargs": self.lookup_kwargs,
                     "query": self.query,
                     "q_objs": str(self.q_objects),
-                    "serializer": serializer,
+                    "serializer": str(serializer),
                 }
             }
         )

--- a/worf/views/list.py
+++ b/worf/views/list.py
@@ -148,9 +148,10 @@ class ListAPI(AbstractBaseAPI):
             return []
 
     def serialize(self):
+        serializer = self.get_serializer()
 
         # Deprecate ------------------------------------------------------------
-        if self.serializer is None:
+        if serializer is None:
             payload = {
                 str(self.name): [
                     getattr(instance, self.api_method)()
@@ -161,8 +162,7 @@ class ListAPI(AbstractBaseAPI):
         else:
             payload = {
                 str(self.name): [
-                    self.serializer(instance).read()
-                    for instance in self.paginated_results
+                    serializer(instance).read() for instance in self.paginated_results
                 ]
             }
 
@@ -192,7 +192,7 @@ class ListAPI(AbstractBaseAPI):
                     "lookup_kwargs": self.lookup_kwargs,
                     "query": self.query,
                     "q_objs": str(self.q_objects),
-                    "serializer": self.serializer,
+                    "serializer": serializer,
                 }
             }
         )


### PR DESCRIPTION
- Allows views to change the serializer during a request by overriding `get_serializer`
- Switches serializers to be instances retrieved via `get_serializer`
- Moves legacy model api method support into a `LegacySerializer` wrapper