### PR TITLE
drop update_fields from detailapi

### DIFF
--- a/worf/testing.py
+++ b/worf/testing.py
@@ -137,8 +137,7 @@ def verify_model_interface(instance, api="api"):
     Right now it's just dumb luck that they match, there's no way to test this
     until now.
 
-    TODO build out api serializers for each model.
-    TODO use this method in the profiles app to test all models' interaces.
+    TODO adapt this to work with Serializer
     """
     if not hasattr(instance, f"{api}_update_fields"):
         warnings.warn(

--- a/worf/views/detail.py
+++ b/worf/views/detail.py
@@ -53,7 +53,7 @@ class DetailAPI(AbstractBaseAPI):
             self.validate_bundle(field)
             setattr(instance, field, self.bundle[field])
 
-        instance.save(update_fields=fields)
+        instance.save()
         instance.refresh_from_db()
 
 


### PR DESCRIPTION
Pinning `update_fields` gains a minute speed improvement for the gotcha that you can't update additional fields by overriding a model's `save()` method