### PR TITLE
Accept empty strings via int

### DIFF
--- a/worf/validators.py
+++ b/worf/validators.py
@@ -63,7 +63,7 @@ class ValidationMixin:
         return strip_tags(self.bundle[key])
 
     def _validate_bundle_int_or_none(self, key):
-        if self.bundle[key] is None or self.bundle[key] == "null":
+        if self.bundle[key] is None or self.bundle[key] == "":
             return None
 
         try:


### PR DESCRIPTION
I imagine wherever we were passing string nulls is long gone, but it'd be good to accept empty strings here, we already accept string ints, and it allows the frontend to be dumber.