### PR TITLE
Pytest TTY flip

### DIFF
--- a/bin/pipenv
+++ b/bin/pipenv
@@ -3,7 +3,7 @@
 set -eou pipefail
 
 if [ -t 0 ] && [ -t 1 ]; then
-  docker exec worf pipenv "$@"
-else
   docker exec -it worf pipenv "$@"
+else
+  docker exec worf pipenv "$@"
 fi


### PR DESCRIPTION
I think these are the wrong way around, annoyingly `docker-compose` is tty opt-out while `docker` is opt-in, so rewriting compose to non-compose gets you the wrong thing if you forget that.