### PR TITLE
Strip strip tags

### DIFF
--- a/worf/validators.py
+++ b/worf/validators.py
@@ -1,4 +1,3 @@
-import re
 from datetime import datetime
 from uuid import UUID
 
@@ -7,7 +6,6 @@ from django.db import models
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
 from django.utils.dateparse import parse_datetime
-from django.utils.html import strip_tags
 
 from worf.exceptions import NotImplementedInWorfYet
 from worf.casing import clean_lookup_keywords, snake_to_camel
@@ -81,7 +79,7 @@ class ValidationMixin:
             raise ValidationError(f"Field {snake_to_camel(key)} accepts string")
 
         if key not in self.secure_fields:
-            value = strip_tags(value).strip()
+            value = value.strip()
 
         if max_length is not None and len(value) > max_length:
             raise ValidationError(


### PR DESCRIPTION
#### What's this PR do?

Strips `strip_tags` from the bundle processing/validation.

#### Where should the reviewer start?

Bundle validation.

#### Why is this important, or what issue does this solve?

Applications will typically handle XSS prevention at the render step, rather than the write step of their application flow.

Stripping html is therefore not a worf concern, and can be handled via middleware or on a case-by-basis rather than applied globally to all fields if anyone wants it.

#### What Worf gif best describes this PR or how it makes you feel?

![data_denied](https://user-images.githubusercontent.com/289531/131494798-5492e5b6-693e-4be6-b192-ba87bec1f495.gif)

#### Tasks

- [x] This PR increases test coverage (removes untested feature)
- [x] This PR improves the documentation (removes undocumented feature)