### PR TITLE
Create and update hooks

### DIFF
--- a/worf/views/create.py
+++ b/worf/views/create.py
@@ -9,9 +9,18 @@ class CreateAPI(AbstractBaseAPI):
         return {}
 
     def post(self, request, *args, **kwargs):
+        new_instance = self.create()
         serializer = self.get_serializer()
+        return self.render_to_response(serializer.read(new_instance), 201)
 
-        create_fields = serializer.create()
+    def create(self):
+        self.validate()
+
+        return self.model.objects.create(**self.bundle)
+
+    def validate(self):
+        create_fields = self.get_serializer().create()
+
         for key in self.bundle.keys():
             self.validate_bundle(key)
             # ignore create_fields for now if it's empty
@@ -22,6 +31,3 @@ class CreateAPI(AbstractBaseAPI):
                         snake_to_camel(key), self.name
                     )
                 )
-
-        new_instance = self.model.objects.create(**self.bundle)
-        return self.render_to_response(serializer.read(new_instance), 201)


### PR DESCRIPTION
#### What's this PR do?

Makes it easier to hook into `create` and `update` ahead of response generation.

#### Where should the reviewer start?

List and Detail views.

#### Why is this important, or what issue does this solve?

Allows for post-save actions that would affect the response, such as saving some m2m relations that Worf can't handle itself, while avoiding serving a stale `get` response afterwards, which is what happens if you override `post`/`patch` to do this.

Mostly I wanted the `create` hook, which doesn't exist in any form, and then if there's a `create` hook, I expect an `update` hook, so I've separated out `validate_and_update` to make that a bit more intuitive. The flow changes a little with validation all happening before assignment starts, but that's fine and maybe better anyway.

There's some bigger things to think about here about this flow, and how we want to recommend overriding these things, but iteratively speaking this is still an improvement over what what it was doing before, so yolo.

#### What Worf gif best describes this PR or how it makes you feel?

![worf_welcome](https://user-images.githubusercontent.com/289531/133425898-3b910924-e0e1-4d91-856f-798581fa3693.gif)

#### Tasks

- [x] This PR increases test coverage