### PR TITLE
Remove search fields early return if not set

### DIFF
--- a/worf/views/list.py
+++ b/worf/views/list.py
@@ -68,9 +68,6 @@ class ListAPI(AbstractBaseAPI):
         For more advanced search use cases, override this method and pass GET
         with any remaining params you want to use classic django filters for.
         """
-        if self.search_fields is None:
-            """If self.search_fields is not set, we don't allow search."""
-            return
 
         self.set_bundle_from_querystring()
         # Whatever is not q or page as a querystring param will


### PR DESCRIPTION
#### What's this PR do?
Removes a condition that would cause any filters to be ignored if you don't set `search_fields`

#### Why is this important, or what issue does this solve?
We, the writers of this code, had to spend time figuring why some filters on an endpoint wouldn't work. It happens that if you don't set `search_fields`, things aren't added to the lookup kwargs. And it seems we have no reasons to require any of them, as the worse it can happen is a query without any args, which is fine.

#### Definition of Done:
- [ ] This PR increases test coverage
- [ ] This PR includes `README` updates reflecting any new features/improvements to the framework
