### PR TITLE
Support annotation filters

### DIFF
--- a/worf/views/list.py
+++ b/worf/views/list.py
@@ -95,11 +95,24 @@ class ListAPI(AbstractBaseAPI):
             return
 
         for key in self.bundle.keys():
-            field = clean_lookup_keywords(key)
             if key not in self.filter_fields:
                 continue
 
-            if isinstance(self.model._meta.get_field(field), ManyToManyField):
+            clean_key = clean_lookup_keywords(key)
+
+            annotation = (
+                self.get_queryset().query.annotations.get(clean_key)
+                if hasattr(self, "get_queryset")
+                else None
+            )
+
+            field = (
+                annotation.output_field
+                if annotation
+                else self.model._meta.get_field(clean_key)
+            )
+
+            if isinstance(field, ManyToManyField):
                 if not isinstance(self.bundle[key], list):
                     # TODO simplify this when we move to POST for search.
                     # We do type coersion in set_bundle_from_querystring,


### PR DESCRIPTION
#### What's this PR do?

Worf currently errors when it can't introspect a field on the model to work out what validation to apply.

Queryset annotations require an `output_field`, so that can be used to determine what validation to apply, and then annotated fields can be supported within `sort_fields` and `filter_fields`.

#### Where should the reviewer start?

#### Why is this important, or what issue does this solve?

#### What Worf gif best describes this PR or how it makes you feel?

#### Definition of Done:
- [ ] This PR increases test coverage
- [ ] This PR includes `README` updates reflecting any new features/improvements to the framework