### PR TITLE
Support string list filters

### DIFF
--- a/tests/test_casing.py
+++ b/tests/test_casing.py
@@ -1,11 +1,6 @@
 import pytest
 
-from worf.casing import (
-    camel_to_snake,
-    clean_lookup_keywords,
-    snake_to_camel,
-    whitespace_to_camel,
-)
+from worf.casing import camel_to_snake, snake_to_camel, whitespace_to_camel
 from worf.exceptions import NamingThingsError
 
 
@@ -48,12 +43,3 @@ def test_snake_to_camel_catches_invalid_chars():
 
 def test_whitespace_to_camel():
     assert "thisIsAVerboseName" == whitespace_to_camel("This is a verbose name")
-
-
-def test_clean_lookup_keywords():
-    assert clean_lookup_keywords("name_with_keyword__gte") == "name_with_keyword"
-    assert clean_lookup_keywords("name_with_keyword__contains") == "name_with_keyword"
-    assert (
-        clean_lookup_keywords("name_with_keyword__not_a_keyword")
-        == "name_with_keyword__not_a_keyword"
-    )

--- a/tests/test_shortcuts.py
+++ b/tests/test_shortcuts.py
@@ -1,0 +1,5 @@
+from worf.shortcuts import get_current_version
+
+
+def test_get_current_version():
+    assert get_current_version().startswith("v")

--- a/tests/views.py
+++ b/tests/views.py
@@ -35,21 +35,12 @@ class ProfileList(ListAPI):
     filter_fields = [
         "date_joined__gte",
         "tags",
+        "tags__in",
     ]
 
 
-class ProfileListSubSet(ListAPI):
-    model = Profile
-    queryset = Profile.objects.annotate(
-        name=Concat("user__first_name", Value(" "), "user__last_name"),
-    ).none()
-    ordering = ["pk"]
-    serializer = ProfileSerializer
-    permissions = [PublicEndpoint]
-    search_fields = []
-    filter_fields = [
-        "tags",
-    ]
+class ProfileListSubSet(ProfileList):
+    queryset = ProfileList.queryset.none()
 
 
 class ProfileDetail(DetailUpdateAPI):

--- a/worf/casing.py
+++ b/worf/casing.py
@@ -1,37 +1,4 @@
-import re
 from worf.exceptions import NamingThingsError
-
-lookup_keywords = [
-    "exact",
-    "iexact",
-    "contains",
-    "icontains",
-    "in",
-    "gt",
-    "gte",
-    "lt",
-    "lte",
-    "startswith",
-    "istartswith",
-    "endswith",
-    "iendswith",
-    "range",
-    "date",
-    "year",
-    "iso_year",
-    "month",
-    "day",
-    "week",
-    "week_day",
-    "quarter",
-    "time",
-    "hour",
-    "minute",
-    "second",
-    "isnull",
-    "regex",
-    "iregex",
-]
 
 
 def snake_to_camel(snake):
@@ -51,7 +18,8 @@ def camel_to_snake(camel):
         return camel
 
     invalid_msg = f"{camel} is not valid camel case. "
-    if not clean_lookup_keywords(camel).isalpha():
+
+    if not camel.replace("__", "").isalpha():
         raise NamingThingsError(invalid_msg + "It has non alphabetical chars!")
 
     snake = ""
@@ -67,6 +35,7 @@ def camel_to_snake(camel):
             snake += value
 
         last_was_upper = value.isupper()
+
     return snake
 
 
@@ -77,7 +46,3 @@ def whitespace_to_camel(string):
 
     new_string = string[:pos] + string[pos + 1 :].capitalize()
     return whitespace_to_camel(new_string)
-
-
-def clean_lookup_keywords(string):
-    return re.sub("__(" + "|".join(lookup_keywords) + ")$", "", string)

--- a/worf/filters.py
+++ b/worf/filters.py
@@ -52,6 +52,6 @@ def generate_filterset(model, queryset):
 
 
 def apply_filterset(filter_set, queryset, lookup_kwargs):
-    data = QueryDict(urlencode(lookup_kwargs))
+    data = QueryDict(urlencode(lookup_kwargs, True))
 
     return filter_set(data=data, queryset=queryset).filter()

--- a/worf/shortcuts.py
+++ b/worf/shortcuts.py
@@ -1,20 +1,6 @@
 import subprocess
 
-from django.conf import settings
-from django.http import Http404
 from worf import __version__
-from worf.exceptions import HTTP404
-
-
-def get_instance_or_http404(model, *args, **kwargs):
-    try:
-        return getattr(getattr(model, "objects"), "get")(*args, **kwargs)
-    except model.DoesNotExist:
-        if settings.DEBUG:
-            raise Http404(
-                "No {} matches the given query.".format(model._meta.object_name)
-            )
-        raise HTTP404()
 
 
 def get_current_version():


### PR DESCRIPTION
#### What's this PR do?

Swaps out the bundle validation of query params in favor of letting django/url_filter deal with it, and adds support for `AND`'s via passing multiple of the same key i.e. `?skill=1&skill=2` ala talent search v1.

**Note:** this switches `?skill=1&skill=2` from performing an `OR` to performing an `AND`. To perform an `in` query pass `?skill__in=1&skill_in=2` or the shorthand of `?skill__in=1,2`. As far as I can see `staff job search` is the only thing doing this, and in the case of `skills` an `and` is probably what is wanted anyway.

#### Where should the reviewer start?

List api filters.

#### Why is this important, or what issue does this solve?

Logical ands were not possible and we only supported lists of integers.

#### What Worf gif best describes this PR or how it makes you feel?

![worf-star-trek](https://user-images.githubusercontent.com/289531/140760941-23547f92-190e-4c6a-8f7b-ab56b5c2ea82.gif)

#### Definition of Done:
- [x] This PR increases test coverage
- [ ] This PR includes `README` updates reflecting any new features/improvements to the framework