### PR TITLE
Annotation filters

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -17,12 +17,23 @@ def test_profile_list(client, db, profile, user):
     assert len(result["profiles"]) == 1
     assert result["profiles"][0]["username"] == user.username
 
+
 def test_profile_list_search(client, db, profile, user):
     response = client.get(f"/profiles/?name={user.first_name} {user.last_name}")
     result = response.json()
     assert response.status_code == 200, result
     assert len(result["profiles"]) == 1
     assert result["profiles"][0]["username"] == user.username
+
+
+def test_profile_list_annotation_filter(client, db, profile_factory):
+    profile_factory.create(user__date_joined="2020-01-01T00:00:00")
+    profile_factory.create(user__date_joined="2020-12-01T00:00:00")
+    response = client.get("/profiles/?dateJoined__gte=2020-06-01T00:00:00")
+    result = response.json()
+    assert response.status_code == 200, result
+    assert len(result["profiles"]) == 1
+
 
 def test_profile_list_subset_search(client, db, profile, user):
     response = client.get(f"/profiles/subset/?name={user.first_name} {user.last_name}")

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -17,6 +17,18 @@ def test_profile_list(client, db, profile, user):
     assert len(result["profiles"]) == 1
     assert result["profiles"][0]["username"] == user.username
 
+def test_profile_list_search(client, db, profile, user):
+    response = client.get(f"/profiles/?name={user.first_name} {user.last_name}")
+    result = response.json()
+    assert response.status_code == 200, result
+    assert len(result["profiles"]) == 1
+    assert result["profiles"][0]["username"] == user.username
+
+def test_profile_list_subset_search(client, db, profile, user):
+    response = client.get(f"/profiles/subset/?name={user.first_name} {user.last_name}")
+    result = response.json()
+    assert response.status_code == 200, result
+
 
 def test_profile_list_array_filter(client, db, profile_factory, tag_factory):
     tag1, tag2, tag3 = tag_factory.create_batch(3)

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,10 +1,11 @@
 from django.urls import include, path
 
-from tests.views import DummyAPI, ProfileDetail, ProfileList, UserDetail, UserList
+from tests.views import DummyAPI, ProfileDetail, ProfileList, ProfileListSubSet, UserDetail, UserList
 
 urlpatterns = [
     path("", DummyAPI.as_view()),
     path("profiles/", ProfileList.as_view()),
+    path("profiles/subset/", ProfileListSubSet.as_view()),
     path("profiles/<str:id>/", ProfileDetail.as_view()),
     path("users/", UserList.as_view()),
     path("users/<str:id>/", UserDetail.as_view()),

--- a/tests/views.py
+++ b/tests/views.py
@@ -1,6 +1,6 @@
 from django.core.exceptions import ValidationError
 from django.contrib.auth.models import User
-from django.db.models import Value
+from django.db.models import F, Value
 from django.db.models.functions import Concat
 
 from worf.permissions import PublicEndpoint
@@ -26,12 +26,14 @@ class ProfileList(ListAPI):
     model = Profile
     queryset = Profile.objects.annotate(
         name=Concat("user__first_name", Value(" "), "user__last_name"),
+        date_joined=F("user__date_joined"),
     )
     ordering = ["pk"]
     serializer = ProfileSerializer
     permissions = [PublicEndpoint]
     search_fields = []
     filter_fields = [
+        "date_joined__gte",
         "tags",
     ]
 

--- a/tests/views.py
+++ b/tests/views.py
@@ -1,5 +1,7 @@
 from django.core.exceptions import ValidationError
 from django.contrib.auth.models import User
+from django.db.models import Value
+from django.db.models.functions import Concat
 
 from worf.permissions import PublicEndpoint
 from worf.views import DetailUpdateAPI, ListAPI
@@ -22,6 +24,9 @@ class DummyAPI(DetailUpdateAPI):
 
 class ProfileList(ListAPI):
     model = Profile
+    queryset = Profile.objects.annotate(
+        name=Concat("user__first_name", Value(" "), "user__last_name"),
+    )
     ordering = ["pk"]
     serializer = ProfileSerializer
     permissions = [PublicEndpoint]
@@ -29,6 +34,10 @@ class ProfileList(ListAPI):
     filter_fields = [
         "tags",
     ]
+
+
+class ProfileListSubSet(ProfileList):
+    queryset = ProfileList.queryset.none()
 
 
 class ProfileDetail(DetailUpdateAPI):

--- a/worf/filters.py
+++ b/worf/filters.py
@@ -1,15 +1,53 @@
 from urllib.parse import urlencode
 
+from django.db.models.fields.related import ForeignObjectRel, RelatedField
 from django.http import QueryDict
 
 from url_filter.filtersets import ModelFilterSet
+from url_filter.exceptions import SkipFilter
 
 
-def generate_filterset(model):
+class AnnotatedModelFilterSet(ModelFilterSet):
+    def get_filters(self):
+        filters = super().get_filters()
+
+        if self.queryset is not None:
+            state = self._build_state()
+
+            for name in self.queryset.query.annotations.keys():
+                if name in self.Meta.exclude or name in filters:
+                    continue
+
+                try:
+                    annotation_filter = self._build_annotation_filter(name, state)
+                except SkipFilter:
+                    continue
+
+                if annotation_filter is not None:
+                    filters[name] = annotation_filter
+
+        return filters
+
+    def _build_annotation_filter(self, name, state):
+        field = self.queryset.query.annotations.get(name).output_field
+
+        if isinstance(field, RelatedField):
+            if not self.Meta.allow_related:
+                raise SkipFilter
+            return self._build_filterset_from_related_field(name, field)
+        elif isinstance(field, ForeignObjectRel):
+            if not self.Meta.allow_related_reverse:
+                raise SkipFilter
+            return self._build_filterset_from_reverse_field(name, field)
+
+        return self._build_filter_from_field(name, field)
+
+
+def generate_filterset(model, queryset):
     return type(
         f"{model.__name__}FilterSet",
-        (ModelFilterSet,),
-        dict(Meta=type("Meta", (), dict(model=model))),
+        (AnnotatedModelFilterSet,),
+        dict(Meta=type("Meta", (), dict(model=model, queryset=queryset))),
     )
 
 

--- a/worf/views/detail.py
+++ b/worf/views/detail.py
@@ -23,7 +23,9 @@ class DetailAPI(AbstractBaseAPI):
         return payload
 
     def get_queryset(self):
-        return (self.queryset or self.model.objects).all()
+        if self.queryset is None:
+            return self.model.objects.all()
+        return self.queryset.all()
 
     def get_instance(self):
         self.lookup_kwargs = {self.lookup_field: self.kwargs[self.lookup_url_kwarg]}

--- a/worf/views/list.py
+++ b/worf/views/list.py
@@ -146,7 +146,9 @@ class ListAPI(AbstractBaseAPI):
             self.lookup_kwargs.update({key: self.bundle[key]})
 
     def get_queryset(self):
-        return (self.queryset or self.model.objects).all()
+        if self.queryset is None:
+            return self.model.objects.all()
+        return self.queryset.all()
 
     def get_processed_queryset(self):
         # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  URL Kwargs

--- a/worf/views/list.py
+++ b/worf/views/list.py
@@ -54,7 +54,7 @@ class ListAPI(AbstractBaseAPI):
 
         # generate a default filterset if a custom one was not provided
         if self.filter_set is None:
-            self.filter_set = generate_filterset(self.model)
+            self.filter_set = generate_filterset(self.model, self.queryset)
 
         # support deprecated search_fields and/or dict syntax (note that `and` does nothing)
         if isinstance(self.search_fields, dict):


### PR DESCRIPTION
#### What's this PR do?

Adds support for generating filters automatically out of annotations applied to view querysets.

This saves client's from repeating the `filter_fields` within a custom filterset when they want to support filtering based on an annotation.

This makes it easier to disconnect the db structure from query param filters supported by a view.

#### Where should the reviewer start?

Annotate some fields on a queryset then add the annotation into `filter_fields`.

#### Why is this important, or what issue does this solve?

Annotations are applied on the queryset not the model, so url_filter's ModelFilterSet doesn't introspect them by default.

#### What Worf gif best describes this PR or how it makes you feel?

#### Tasks

- [x] This PR increases test coverage
- [ ] This PR includes `README` updates reflecting any new features/improvements to the framework