### PR TITLE
Fix get_queryset and new tests

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -18,6 +18,20 @@ def test_profile_list(client, db, profile, user):
     assert result["profiles"][0]["username"] == user.username
 
 
+def test_profile_list_search(client, db, profile, user):
+    response = client.get(f"/profiles/?name={user.first_name} {user.last_name}")
+    result = response.json()
+    assert response.status_code == 200, result
+    assert len(result["profiles"]) == 1
+    assert result["profiles"][0]["username"] == user.username
+
+
+def test_profile_list_subset_search(client, db, profile, user):
+    response = client.get(f"/profiles/subset/?name={user.first_name} {user.last_name}")
+    result = response.json()
+    assert response.status_code == 200, result
+
+
 def test_profile_list_array_filter(client, db, profile_factory, tag_factory):
     tag1, tag2, tag3 = tag_factory.create_batch(3)
     profile_factory.create(tags=[tag1])

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,10 +1,18 @@
 from django.urls import include, path
 
-from tests.views import DummyAPI, ProfileDetail, ProfileList, UserDetail, UserList
+from tests.views import (
+    DummyAPI,
+    ProfileDetail,
+    ProfileList,
+    ProfileListSubSet,
+    UserDetail,
+    UserList,
+)
 
 urlpatterns = [
     path("", DummyAPI.as_view()),
     path("profiles/", ProfileList.as_view()),
+    path("profiles/subset/", ProfileListSubSet.as_view()),
     path("profiles/<str:id>/", ProfileDetail.as_view()),
     path("users/", UserList.as_view()),
     path("users/<str:id>/", UserDetail.as_view()),

--- a/tests/views.py
+++ b/tests/views.py
@@ -1,5 +1,7 @@
 from django.core.exceptions import ValidationError
 from django.contrib.auth.models import User
+from django.db.models import Value
+from django.db.models.functions import Concat
 
 from worf.permissions import PublicEndpoint
 from worf.views import DetailUpdateAPI, ListAPI
@@ -22,6 +24,23 @@ class DummyAPI(DetailUpdateAPI):
 
 class ProfileList(ListAPI):
     model = Profile
+    queryset = Profile.objects.annotate(
+        name=Concat("user__first_name", Value(" "), "user__last_name"),
+    )
+    ordering = ["pk"]
+    serializer = ProfileSerializer
+    permissions = [PublicEndpoint]
+    search_fields = []
+    filter_fields = [
+        "tags",
+    ]
+
+
+class ProfileListSubSet(ListAPI):
+    model = Profile
+    queryset = Profile.objects.annotate(
+        name=Concat("user__first_name", Value(" "), "user__last_name"),
+    ).none()
     ordering = ["pk"]
     serializer = ProfileSerializer
     permissions = [PublicEndpoint]

--- a/worf/views/detail.py
+++ b/worf/views/detail.py
@@ -23,7 +23,9 @@ class DetailAPI(AbstractBaseAPI):
         return payload
 
     def get_queryset(self):
-        return (self.queryset or self.model.objects).all()
+        if self.queryset is None:
+            return self.model.objects.all()
+        return self.queryset.all()
 
     def get_instance(self):
         self.lookup_kwargs = {self.lookup_field: self.kwargs[self.lookup_url_kwarg]}

--- a/worf/views/list.py
+++ b/worf/views/list.py
@@ -146,7 +146,9 @@ class ListAPI(AbstractBaseAPI):
             self.lookup_kwargs.update({key: self.bundle[key]})
 
     def get_queryset(self):
-        return (self.queryset or self.model.objects).all()
+        if self.queryset is None:
+            return self.model.objects.all()
+        return self.queryset.all()
 
     def get_processed_queryset(self):
         # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  URL Kwargs


### PR DESCRIPTION
#### What's this PR do?
It fix the `get_queryset` method, which would return `self.model.objects.all()` if a `queryset` was set but the results were empty

#### Where should the reviewer start?
The `ListAPI` and `DetailAPI`

#### Why is this important, or what issue does this solve?
It would cause annotated fields to be lost and solves a security vulnerability

#### Definition of Done:
- [x] This PR increases test coverage
- [ ] This PR includes `README` updates reflecting any new features/improvements to the framework
