### PR TITLE
Switch out some snake_to_camel usage for a keymap

### DIFF
--- a/tests/test_casing.py
+++ b/tests/test_casing.py
@@ -1,6 +1,6 @@
 import pytest
 
-from worf.casing import camel_to_snake, snake_to_camel, whitespace_to_camel
+from worf.casing import camel_to_snake, snake_to_camel
 from worf.exceptions import NamingThingsError
 
 
@@ -39,7 +39,3 @@ def test_camel_to_snake_catches_invalid_chars():
 def test_snake_to_camel_catches_invalid_chars():
     with pytest.raises(NamingThingsError):
         snake_to_camel("this_aint_no_🐍")
-
-
-def test_whitespace_to_camel():
-    assert "thisIsAVerboseName" == whitespace_to_camel("This is a verbose name")

--- a/worf/casing.py
+++ b/worf/casing.py
@@ -37,12 +37,3 @@ def camel_to_snake(camel):
         last_was_upper = value.isupper()
 
     return snake
-
-
-def whitespace_to_camel(string):
-    pos = string.find(" ")
-    if pos == -1:
-        return string[:1].lower() + string[1:]
-
-    new_string = string[:pos] + string[pos + 1 :].capitalize()
-    return whitespace_to_camel(new_string)

--- a/worf/validators.py
+++ b/worf/validators.py
@@ -8,7 +8,6 @@ from django.core.validators import validate_email
 from django.utils.dateparse import parse_datetime
 
 from worf.exceptions import NotImplementedInWorfYet
-from worf.casing import snake_to_camel
 
 
 class ValidationMixin:
@@ -36,7 +35,7 @@ class ValidationMixin:
 
         if not isinstance(coerced, bool):
             raise ValidationError(
-                f"Field {snake_to_camel(key)} accepts a boolean, got {value}, coerced to {coerced}"
+                f"Field {self.keymap[key]} accepts a boolean, got {value}, coerced to {coerced}"
             )
 
         return coerced
@@ -58,7 +57,7 @@ class ValidationMixin:
 
         if not isinstance(coerced, datetime):
             raise ValidationError(
-                f"Field {snake_to_camel(key)} accepts a iso datetime string, got {value}, coerced to {coerced}"
+                f"Field {self.keymap[key]} accepts a iso datetime string, got {value}, coerced to {coerced}"
             )
 
         return coerced
@@ -68,18 +67,18 @@ class ValidationMixin:
 
         if not isinstance(value, list):
             raise ValidationError(
-                f"Field {snake_to_camel(key)} accepts an array, got {type(value)} {value}"
+                f"Field {self.keymap[key]} accepts an array, got {type(value)} {value}"
             )
 
     def _validate_string(self, key, max_length):
         value = self.bundle[key]
 
         if not isinstance(value, str):
-            raise ValidationError(f"Field {snake_to_camel(key)} accepts string")
+            raise ValidationError(f"Field {self.keymap[key]} accepts string")
 
         if max_length is not None and len(value) > max_length:
             raise ValidationError(
-                f"Field {snake_to_camel(key)} accepts a maximum of {max_length} characters"
+                f"Field {self.keymap[key]} accepts a maximum of {max_length} characters"
             )
 
         return value
@@ -93,7 +92,7 @@ class ValidationMixin:
         try:
             integer = int(value)
         except (TypeError, ValueError):
-            raise ValidationError(f"Field {snake_to_camel(key)} accepts an integer")
+            raise ValidationError(f"Field {self.keymap[key]} accepts an integer")
 
         return integer
 
@@ -102,7 +101,7 @@ class ValidationMixin:
 
         if integer < 0:
             raise ValidationError(
-                f"Field {snake_to_camel(key)} accepts a positive integer"
+                f"Field {self.keymap[key]} accepts a positive integer"
             )
 
         return integer
@@ -113,7 +112,7 @@ class ValidationMixin:
         try:
             self.bundle[key] = [int(id) for id in self.bundle[key]]
         except ValueError:
-            message = f"Field {snake_to_camel(key)} accepts an array of integers. Got {self.bundle[key]} instead."
+            message = f"Field {self.keymap[key]} accepts an array of integers. Got {self.bundle[key]} instead."
             raise ValidationError(message + " I couldn't coerce the values.")
 
     def validate_int(self, value):
@@ -167,7 +166,7 @@ class ValidationMixin:
         serializer = self.get_serializer()
 
         if self.request.method in ("PATCH", "PUT") and key not in serializer.write():
-            message = f"{snake_to_camel(key)} is not editable"
+            message = f"{self.keymap[key]} is not editable"
             if settings.DEBUG:
                 message += f":: {serializer}"
             raise ValidationError(message)
@@ -179,7 +178,7 @@ class ValidationMixin:
         )
 
         if not hasattr(self.model, key) and not annotation:
-            raise ValidationError(f"{snake_to_camel(key)} does not exist")
+            raise ValidationError(f"{self.keymap[key]} does not exist")
 
         if key not in self.secure_fields and isinstance(self.bundle[key], str):
             self.bundle[key] = self.bundle[key].strip()
@@ -231,7 +230,7 @@ class ValidationMixin:
             # try:
             #     json.loads(self.bundle[key])
             # except ValueError:
-            #     raise ValidationError(f"Field {snake_to_camel(key)} requires valid JSON")
+            #     raise ValidationError(f"Field {self.keymap[key]} requires valid JSON")
 
         else:
             message = f"{field.get_internal_type()} has no validation method for {key}"

--- a/worf/views/create.py
+++ b/worf/views/create.py
@@ -1,6 +1,5 @@
 from django.core.exceptions import ValidationError
 
-from worf.casing import snake_to_camel
 from worf.views.base import AbstractBaseAPI
 
 
@@ -27,7 +26,5 @@ class CreateAPI(AbstractBaseAPI):
             # this should be moved into validate bundle
             if create_fields and key not in create_fields:
                 raise ValidationError(
-                    "{} not allowed when creating {}".format(
-                        snake_to_camel(key), self.name
-                    )
+                    f"{self.keymap[key]} not allowed when creating {self.name}"
                 )

--- a/worf/views/detail.py
+++ b/worf/views/detail.py
@@ -2,7 +2,6 @@ from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.db import models
 from django.db.utils import IntegrityError
 
-from worf.casing import snake_to_camel
 from worf.views.base import AbstractBaseAPI
 
 
@@ -46,14 +45,14 @@ class DetailAPI(AbstractBaseAPI):
                 else None
             )
         except related_model.DoesNotExist as e:
-            raise ValidationError(f"Invalid {snake_to_camel(key)}") from e
+            raise ValidationError(f"Invalid {self.keymap[key]}") from e
         setattr(instance, key, related_instance)
 
     def set_many_to_many(self, instance, key):
         try:
             getattr(instance, key).set(self.bundle[key])
         except (IntegrityError, ValueError) as e:
-            raise ValidationError(f"Invalid {snake_to_camel(key)}") from e
+            raise ValidationError(f"Invalid {self.keymap[key]}") from e
 
     def set_many_to_many_with_through(self, instance, key):
         try:
@@ -83,7 +82,7 @@ class DetailAPI(AbstractBaseAPI):
                 ]
             )
         except (AttributeError, IntegrityError, ValueError) as e:
-            raise ValidationError(f"Invalid {snake_to_camel(key)}") from e
+            raise ValidationError(f"Invalid {self.keymap[key]}") from e
 
     def update(self):
         instance = self.get_instance()
@@ -119,7 +118,7 @@ class DetailAPI(AbstractBaseAPI):
             field = self.model._meta.get_field(key)
 
             if self.bundle[key] is None and not field.null:
-                raise ValidationError(f"Invalid {snake_to_camel(key)}")
+                raise ValidationError(f"Invalid {self.keymap[key]}")
 
 
 class DetailUpdateAPI(DetailAPI):


### PR DESCRIPTION
#### What's this PR do?

Switch out `snake_to_camel` usage where we're attempting to recreate the name of the field the client supplied, because we know the name they supplied, and it might not be what `snake_to_camel` produces.

Also drops `whitespace_to_camel` which seems to do the same thing as `snake_to_camel(thing.replace(" ", "_").lower())` and I'd rather maintain fewer casing helpers.

#### Where should the reviewer start?

Bundle processing.

#### Why is this important, or what issue does this solve?

In a world where we accept complex lookups via filter params with `__` in them we can't reliably camelize snake case and get the right thing out.

Also, we technically support snake case, and without this change our errors will describe the fields back to the client in camel case, regardless of what they passed, which is confusing.

#### Tasks

- [x] This PR increases test coverage
- [ ] This PR includes `README` updates reflecting any new features/improvements to the framework