### PR TITLE
Assign fk/m2m on create and support delete

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
 addopts =
     --cov
-    --cov-fail-under 75
+    --cov-fail-under 78
     --cov-report term:skip-covered
     --cov-report html
     --no-cov-on-fail

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,12 @@
 import pytest
 from pytest_factoryboy import register
 
-import django
-from django.conf import settings
-from django.utils import timezone
-
 
 def pytest_configure():
     """Initialize Django settings."""
+    import django
+    from django.conf import settings
+
     settings.configure(
         SECRET_KEY="secret",
         DEBUG=True,
@@ -61,16 +60,33 @@ def pytest_configure():
     register(UserFactory, "user")
 
 
+@pytest.fixture(name="admin_client")
+def admin_client_fixture(db, admin_user):
+    from worf.testing import ApiClient
+
+    client = ApiClient()
+    client.force_login(admin_user)
+    return client
+
+
+@pytest.fixture(name="client")
+def client_fixture():
+    from worf.testing import ApiClient
+
+    return ApiClient()
+
+
 @pytest.fixture(name="now")
 def now_fixture():
+    from django.utils import timezone
+
     return timezone.now()
 
 
-@pytest.fixture(name="profile_url")
-def profile_url_fixture(profile):
-    return f"/profiles/{profile.pk}/"
+@pytest.fixture(name="user_client")
+def user_client_fixture(db, user):
+    from worf.testing import ApiClient
 
-
-@pytest.fixture(name="user_url")
-def user_url_fixture(user):
-    return f"/users/{user.pk}/"
+    client = ApiClient()
+    client.force_login(user)
+    return client

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,11 +1,20 @@
+from uuid import uuid4
+
 from django.db import models
 from django.contrib.auth.models import User
 
 
-class DummyModel(models.Model):
-    id = models.CharField(max_length=64, primary_key=True)
+class Profile(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid4)
+
     email = models.CharField(max_length=64)
     phone = models.CharField(max_length=64)
+
+    user = models.OneToOneField(User, on_delete=models.CASCADE)
+    role = models.ForeignKey("Role", on_delete=models.CASCADE)
+    team = models.ForeignKey("Team", blank=True, null=True, on_delete=models.SET_NULL)
+    skills = models.ManyToManyField("Skill", through="RatedSkill")
+    tags = models.ManyToManyField("Tag")
 
     def api(self):
         return dict(id=self.id, email=self.email, phone=self.phone)
@@ -72,11 +81,3 @@ class Tag(models.Model):
 
 class Team(models.Model):
     name = models.CharField(max_length=64)
-
-
-class Profile(models.Model):
-    user = models.OneToOneField(User, on_delete=models.CASCADE)
-    role = models.ForeignKey(Role, on_delete=models.CASCADE)
-    team = models.ForeignKey(Team, blank=True, null=True, on_delete=models.SET_NULL)
-    skills = models.ManyToManyField(Skill, through=RatedSkill)
-    tags = models.ManyToManyField(Tag)

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,82 +1,65 @@
 import pytest
-from uuid import UUID
+
+from uuid import uuid4
 
 from django.core.exceptions import ValidationError
-from django.test import RequestFactory
 
-from tests.models import DummyModel
-from tests.views import DummyAPI
-
-test_uuid = "ce6a5b4f-599d-4442-8a74-d7a8d2b54854"
-test_email = "something@example.com"
-test_phone = "(555) 555-5555"
+uuid = uuid4()
+email = "something@example.com"
+phone = "(555) 555-5555"
 
 
-@pytest.fixture
-@pytest.mark.django_db
-def view():
-    view = DummyAPI()
+@pytest.fixture(name="profile_view")
+def profile_view_fixture(db, profile_factory):
+    from django.test import RequestFactory
+
+    from tests.views import ProfileDetail
+
+    profile_factory.create(email=email, phone=phone)
+    view = ProfileDetail()
     view.bundle = {
-        "id": test_uuid,
-        "email": test_email,
-        "phone": test_phone,
+        "id": str(uuid),
+        "email": email,
+        "phone": phone,
     }
-    DummyModel.objects.create(id=UUID(test_uuid), email=test_email, phone=test_phone)
-    view.request = RequestFactory().patch(f"/{test_uuid}/")
-    view.kwargs = dict(id=test_uuid)
+    view.request = RequestFactory().patch(f"/{uuid}/")
+    view.kwargs = dict(id=str(uuid))
+    view.serializer = None
     return view
 
 
-@pytest.mark.django_db
-def test_validate_bundle(view):
-    assert view.validate_bundle("id")
-    assert view.validate_bundle("email")
-    assert view.validate_bundle("phone")
+def test_validate_bundle(profile_view):
+    assert profile_view.validate_bundle("id")
+    assert profile_view.validate_bundle("email")
+    assert profile_view.validate_bundle("phone")
 
 
-@pytest.mark.django_db
-def test_validate_uuid_accepts_str(view):
-    string = "ce6a5b4f-599d-4442-8a74-d7a8d2b54854"
-    result = view.validate_uuid(string)
-    assert result == UUID(string)
+def test_validate_uuid_accepts_str(profile_view):
+    assert profile_view.validate_uuid(str(uuid)) == uuid
 
 
-@pytest.mark.django_db
-def test_validate_uuid_accepts_uuid(view):
-    uuid = UUID("ce6a5b4f-599d-4442-8a74-d7a8d2b54854")
-    result = view.validate_uuid(uuid)
-    assert result == uuid
+def test_validate_uuid_accepts_uuid(profile_view):
+    assert profile_view.validate_uuid(uuid) == uuid
 
 
-@pytest.mark.django_db
-def test_validate_uuid_raises_error(view):
-    string = "not-a-uuid"
+def test_validate_uuid_raises_error(profile_view):
     with pytest.raises(ValidationError):
-        view.validate_uuid(string)
+        profile_view.validate_uuid("not-a-uuid")
 
 
-@pytest.mark.django_db
-def test_validate_email_passes(view):
-    email = "something@example.com"
-    result = view.validate_email(email)
-    assert email == result
+def test_validate_email_passes(profile_view):
+    assert profile_view.validate_email(email) == email
 
 
-@pytest.mark.django_db
-def test_validate_email_raises_error(view):
-    email = "fake.example@com"
+def test_validate_email_raises_error(profile_view):
     with pytest.raises(ValidationError):
-        view.validate_email(email)
+        profile_view.validate_email("fake.example@com")
 
 
-@pytest.mark.django_db
-def test_validate_custom_field_passes(view):
-    phone = "(555) 555-5555"
-    assert view.validate_phone(phone) == "+5555555555"
+def test_validate_custom_field_passes(profile_view):
+    assert profile_view.validate_phone(phone) == "+5555555555"
 
 
-@pytest.mark.django_db
-def test_validate_custom_field_raises_error(view):
-    phone = "invalid number"
+def test_validate_custom_field_raises_error(profile_view):
     with pytest.raises(ValidationError):
-        view.validate_phone(phone)
+        profile_view.validate_phone("invalid number")

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,7 +1,6 @@
 from django.urls import include, path
 
 from tests.views import (
-    DummyAPI,
     ProfileDetail,
     ProfileList,
     ProfileListSubSet,
@@ -10,11 +9,9 @@ from tests.views import (
 )
 
 urlpatterns = [
-    path("", DummyAPI.as_view()),
     path("profiles/", ProfileList.as_view()),
     path("profiles/subset/", ProfileListSubSet.as_view()),
     path("profiles/<str:id>/", ProfileDetail.as_view()),
     path("users/", UserList.as_view()),
     path("users/<str:id>/", UserDetail.as_view()),
-    path("<str:id>/", DummyAPI.as_view()),
 ]

--- a/tests/views.py
+++ b/tests/views.py
@@ -4,22 +4,10 @@ from django.db.models import F, Value
 from django.db.models.functions import Concat
 
 from worf.permissions import PublicEndpoint
-from worf.views import DetailUpdateAPI, ListAPI
+from worf.views import DeleteAPI, DetailAPI, DetailUpdateAPI, ListAPI, UpdateAPI
 
-from tests.models import DummyModel, Profile
+from tests.models import Profile
 from tests.serializers import ProfileSerializer, UserSerializer
-
-
-class DummyAPI(DetailUpdateAPI):
-    model = DummyModel
-    permissions = [PublicEndpoint]
-
-    def validate_phone(self, value):
-        try:
-            assert value == "(555) 555-5555"
-        except AssertionError:
-            raise ValidationError("{value} is not a valid phone number")
-        return "+5555555555"
 
 
 class ProfileList(ListAPI):
@@ -43,10 +31,17 @@ class ProfileListSubSet(ProfileList):
     queryset = ProfileList.queryset.none()
 
 
-class ProfileDetail(DetailUpdateAPI):
+class ProfileDetail(DeleteAPI, UpdateAPI, DetailAPI):
     model = Profile
     serializer = ProfileSerializer
     permissions = [PublicEndpoint]
+
+    def validate_phone(self, value):
+        try:
+            assert value == "(555) 555-5555"
+        except AssertionError:
+            raise ValidationError("{value} is not a valid phone number")
+        return "+5555555555"
 
 
 class UserList(ListAPI):

--- a/worf/assigns.py
+++ b/worf/assigns.py
@@ -1,0 +1,89 @@
+from django.core.exceptions import ValidationError
+from django.db import models
+from django.db.utils import IntegrityError
+
+
+class AssignAttributes:
+    def save(self, instance, bundle):
+        items = [
+            (key, getattr(self.model, key), value) for key, value in bundle.items()
+        ]
+
+        for key, attr, value in items:
+            if isinstance(value, models.Model):
+                setattr(instance, key, value)
+                continue
+
+            if isinstance(attr.field, models.ForeignKey):
+                self.set_foreign_key(instance, key, value)
+                continue
+
+            if isinstance(attr.field, models.ManyToManyField):
+                continue
+
+            setattr(instance, key, value)
+
+        instance.save()
+
+        for key, attr, value in items:
+            if isinstance(attr.field, models.ManyToManyField):
+                if not attr.through._meta.auto_created:
+                    self.set_many_to_many_with_through(instance, key, value)
+                    continue
+
+                self.set_many_to_many(instance, key, value)
+
+    def set_foreign_key(self, instance, key, value):
+        related_model = self.get_related_model(key)
+        try:
+            related_instance = (
+                related_model.objects.get(pk=value) if value is not None else None
+            )
+        except related_model.DoesNotExist as e:
+            raise ValidationError(f"Invalid {self.keymap[key]}") from e
+        setattr(instance, key, related_instance)
+
+    def set_many_to_many(self, instance, key, value):
+        try:
+            getattr(instance, key).set(value)
+        except (IntegrityError, ValueError) as e:
+            raise ValidationError(f"Invalid {self.keymap[key]}") from e
+
+    def set_many_to_many_with_through(self, instance, key, value):
+        try:
+            attr = getattr(self.model, key)
+
+            through_model = attr.through
+            model_name = self.model._meta.model_name
+            target_field_name = attr.field.m2m_target_field_name()
+            reverse_name = attr.field.m2m_reverse_name()
+
+            getattr(instance, key).clear()
+
+            through_model.objects.bulk_create(
+                [
+                    through_model(
+                        **{
+                            item_key: item_value
+                            for item_key, item_value in item.items()
+                            if item_key != target_field_name
+                        },
+                        **{
+                            model_name: instance,
+                            reverse_name: item[target_field_name],
+                        },
+                    )
+                    for item in value
+                ]
+            )
+        except (AttributeError, IntegrityError, ValueError) as e:
+            raise ValidationError(f"Invalid {self.keymap[key]}") from e
+
+    def validate(self):
+        for key in self.bundle.keys():
+            self.validate_bundle(key)
+
+            field = self.model._meta.get_field(key)
+
+            if self.bundle[key] is None and not field.null:
+                raise ValidationError(f"Invalid {self.keymap[key]}")

--- a/worf/lookups.py
+++ b/worf/lookups.py
@@ -1,0 +1,19 @@
+class FindInstance:
+    lookup_field = "id"
+    lookup_url_kwarg = "id"
+    queryset = None
+
+    def get_instance(self):
+        self.lookup_kwargs = {self.lookup_field: self.kwargs[self.lookup_url_kwarg]}
+
+        self.validate_lookup_field_values()
+
+        if not hasattr(self, "instance"):
+            self.instance = self.get_queryset().get(**self.lookup_kwargs)
+
+        return self.instance
+
+    def get_queryset(self):
+        if self.queryset is None:
+            return self.model.objects.all()
+        return self.queryset.all()

--- a/worf/testing.py
+++ b/worf/testing.py
@@ -1,0 +1,10 @@
+from functools import partialmethod
+
+from django.test.client import Client
+
+
+class ApiClient(Client):
+    delete = partialmethod(Client.delete, content_type="application/json")
+    patch = partialmethod(Client.patch, content_type="application/json")
+    post = partialmethod(Client.post, content_type="application/json")
+    put = partialmethod(Client.put, content_type="application/json")

--- a/worf/transformers.py
+++ b/worf/transformers.py
@@ -1,7 +1,0 @@
-def transform_to_dict(choices):
-    """Convert various choices list of lists into json object."""
-    # TODO this is copied from context_processors.
-    transformed_choices = dict()
-    for each in choices:
-        transformed_choices[each[0]] = each[1]
-    return transformed_choices

--- a/worf/validators.py
+++ b/worf/validators.py
@@ -196,6 +196,9 @@ class ValidationMixin:
         elif hasattr(self, f"validate_{key}"):
             self.bundle[key] = getattr(self, f"validate_{key}")(self.bundle[key])
 
+        elif isinstance(field, models.UUIDField):
+            self.bundle[key] = self.validate_uuid(self.bundle[key])
+
         elif isinstance(field, (models.CharField, models.TextField, models.SlugField)):
             self.bundle[key] = self._validate_string(key, field.max_length)
 

--- a/worf/views/__init__.py
+++ b/worf/views/__init__.py
@@ -1,4 +1,6 @@
 from worf.views.base import APIResponse, AbstractBaseAPI  # noqa
 from worf.views.create import CreateAPI  # noqa
+from worf.views.delete import DeleteAPI  # noqa
 from worf.views.detail import DetailAPI, DetailUpdateAPI  # noqa
 from worf.views.list import ListAPI, ListCreateAPI  # noqa
+from worf.views.update import UpdateAPI  # noqa

--- a/worf/views/base.py
+++ b/worf/views/base.py
@@ -11,7 +11,7 @@ from django.core.exceptions import (
     ValidationError,
 )
 from django.db import models
-from django.http import JsonResponse
+from django.http import HttpResponse, JsonResponse
 from django.middleware.gzip import GZipMiddleware
 from django.views import View
 from django.views.decorators.cache import never_cache
@@ -42,7 +42,7 @@ class APIResponse(View):
             msg += "render_to_response, nor did its serializer method"
             raise ImproperlyConfigured(msg)
 
-        response = JsonResponse(payload)
+        response = JsonResponse(payload) if payload != "" else HttpResponse()
         # except TypeError:
         # TODO add something meaningful to the stack trace
 

--- a/worf/views/create.py
+++ b/worf/views/create.py
@@ -1,30 +1,19 @@
-from django.core.exceptions import ValidationError
-
+from worf.assigns import AssignAttributes
 from worf.views.base import AbstractBaseAPI
 
 
-class CreateAPI(AbstractBaseAPI):
-    def serialize(self):
-        return {}
+class CreateAPI(AssignAttributes, AbstractBaseAPI):
+    def create(self):
+        instance = self.get_instance()
+        self.validate()
+        self.save(instance, self.bundle)
+        instance.refresh_from_db()
+        return instance
+
+    def get_instance(self):
+        return self.model()
 
     def post(self, request, *args, **kwargs):
         new_instance = self.create()
         serializer = self.get_serializer()
         return self.render_to_response(serializer.read(new_instance), 201)
-
-    def create(self):
-        self.validate()
-
-        return self.model.objects.create(**self.bundle)
-
-    def validate(self):
-        create_fields = self.get_serializer().create()
-
-        for key in self.bundle.keys():
-            self.validate_bundle(key)
-            # ignore create_fields for now if it's empty
-            # this should be moved into validate bundle
-            if create_fields and key not in create_fields:
-                raise ValidationError(
-                    f"{self.keymap[key]} not allowed when creating {self.name}"
-                )

--- a/worf/views/delete.py
+++ b/worf/views/delete.py
@@ -1,0 +1,10 @@
+from worf.views.base import AbstractBaseAPI
+
+
+class DeleteAPI(AbstractBaseAPI):
+    def delete(self, request, *args, **kwargs):
+        self.destroy()
+        return self.render_to_response("", 204)
+
+    def destroy(self):
+        self.get_instance().delete()

--- a/worf/views/detail.py
+++ b/worf/views/detail.py
@@ -1,15 +1,11 @@
-from django.core.exceptions import ImproperlyConfigured, ValidationError
-from django.db import models
-from django.db.utils import IntegrityError
+from django.core.exceptions import ImproperlyConfigured
 
+from worf.lookups import FindInstance
 from worf.views.base import AbstractBaseAPI
+from worf.views.update import UpdateAPI
 
 
-class DetailAPI(AbstractBaseAPI):
-    lookup_field = "id"
-    lookup_url_kwarg = "id"
-    queryset = None
-
+class DetailAPI(FindInstance, AbstractBaseAPI):
     def get(self, request, *args, **kwargs):
         return self.render_to_response()
 
@@ -21,107 +17,8 @@ class DetailAPI(AbstractBaseAPI):
             raise ImproperlyConfigured(f"{serializer} did not return a dictionary")
         return payload
 
-    def get_queryset(self):
-        if self.queryset is None:
-            return self.model.objects.all()
-        return self.queryset.all()
 
-    def get_instance(self):
-        self.lookup_kwargs = {self.lookup_field: self.kwargs[self.lookup_url_kwarg]}
-
-        self.validate_lookup_field_values()
-
-        if not hasattr(self, "instance"):
-            self.instance = self.get_queryset().get(**self.lookup_kwargs)
-
-        return self.instance
-
-    def set_foreign_key(self, instance, key):
-        related_model = self.get_related_model(key)
-        try:
-            related_instance = (
-                related_model.objects.get(pk=self.bundle[key])
-                if self.bundle[key] is not None
-                else None
-            )
-        except related_model.DoesNotExist as e:
-            raise ValidationError(f"Invalid {self.keymap[key]}") from e
-        setattr(instance, key, related_instance)
-
-    def set_many_to_many(self, instance, key):
-        try:
-            getattr(instance, key).set(self.bundle[key])
-        except (IntegrityError, ValueError) as e:
-            raise ValidationError(f"Invalid {self.keymap[key]}") from e
-
-    def set_many_to_many_with_through(self, instance, key):
-        try:
-            attr = getattr(self.model, key)
-
-            through_model = attr.through
-            model_name = self.model._meta.model_name
-            target_field_name = attr.field.m2m_target_field_name()
-            reverse_name = attr.field.m2m_reverse_name()
-
-            getattr(instance, key).clear()
-
-            through_model.objects.bulk_create(
-                [
-                    through_model(
-                        **{
-                            key: value
-                            for key, value in item.items()
-                            if key != target_field_name
-                        },
-                        **{
-                            model_name: instance,
-                            reverse_name: item[target_field_name],
-                        },
-                    )
-                    for item in self.bundle[key]
-                ]
-            )
-        except (AttributeError, IntegrityError, ValueError) as e:
-            raise ValidationError(f"Invalid {self.keymap[key]}") from e
-
-    def update(self):
-        instance = self.get_instance()
-
-        self.validate()
-
-        for key in self.bundle.keys():
-            attr = getattr(self.model, key)
-
-            if isinstance(attr.field, models.ForeignKey):
-                self.set_foreign_key(instance, key)
-                continue
-
-            if isinstance(attr.field, models.ManyToManyField):
-                if not attr.through._meta.auto_created:
-                    self.set_many_to_many_with_through(instance, key)
-                    continue
-
-                self.set_many_to_many(instance, key)
-                continue
-
-            setattr(instance, key, self.bundle[key])
-
-        instance.save()
-        instance.refresh_from_db()
-
-        return instance
-
-    def validate(self):
-        for key in self.bundle.keys():
-            self.validate_bundle(key)
-
-            field = self.model._meta.get_field(key)
-
-            if self.bundle[key] is None and not field.null:
-                raise ValidationError(f"Invalid {self.keymap[key]}")
-
-
-class DetailUpdateAPI(DetailAPI):
+class DetailUpdateAPI(UpdateAPI, DetailAPI):
     def patch(self, request, *args, **kwargs):
         self.update()
         return self.get(request)

--- a/worf/views/list.py
+++ b/worf/views/list.py
@@ -29,9 +29,6 @@ class ListAPI(AbstractBaseAPI):
     max_per_page = None
     num_pages = 1
 
-    def get(self, request, *args, **kwargs):
-        return self.render_to_response()
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -62,6 +59,9 @@ class ListAPI(AbstractBaseAPI):
                 f"Passing a dict to {codepath}.search_fields is deprecated. Pass a list instead."
             )
             self.search_fields = self.search_fields.get("or", [])
+
+    def get(self, request, *args, **kwargs):
+        return self.render_to_response()
 
     def _set_base_lookup_kwargs(self):
         # Filters set directly on the class
@@ -243,5 +243,5 @@ class ListAPI(AbstractBaseAPI):
         return payload
 
 
-class ListCreateAPI(ListAPI, CreateAPI):
+class ListCreateAPI(CreateAPI, ListAPI):
     pass

--- a/worf/views/update.py
+++ b/worf/views/update.py
@@ -1,0 +1,20 @@
+from worf.assigns import AssignAttributes
+from worf.lookups import FindInstance
+from worf.views.base import AbstractBaseAPI
+
+
+class UpdateAPI(AssignAttributes, FindInstance, AbstractBaseAPI):
+    def patch(self, request, *args, **kwargs):
+        self.update()
+        return self.render_to_response()
+
+    def put(self, request, *args, **kwargs):
+        self.update()
+        return self.render_to_response()
+
+    def update(self):
+        instance = self.get_instance()
+        self.validate()
+        self.save(instance, self.bundle)
+        instance.refresh_from_db()
+        return instance


### PR DESCRIPTION
#### What's this PR do?

- Expands `create` to support fk/m2m assignment
- Adds support for `delete` with a blank 204 response
- Adds `ApiClient` to `worf.testing` which defaults to json
- Refactors views and tests
- Removes `transform_to_dict` which does the same thing as `dict`
- Bumps test coverage to 78%

#### Why is this important, or what issue does this solve?

I needed to create and delete things, and I wanted to do it in style 😼 

#### What Worf gif best describes this PR or how it makes you feel?

![worf_parry](https://user-images.githubusercontent.com/289531/141471792-993da9df-5497-4bc3-810a-960782504295.gif)

#### Tasks

- [x] This PR increases test coverage
- [ ] This PR includes `README` updates reflecting any new features/improvements to the framework