### PR TITLE
File upload support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Table of contents
     - [UpdateAPI](#updateapi)
   - [Bundle loading](#bundle-loading)
   - [Field casing](#field-casing)
+  - [File uploads](#file-uploads)
   - [Internal naming](#internal-naming)
   - [Credits](#credits)
 
@@ -56,8 +57,9 @@ Roadmap
 - [x] Abstracting serializers away from model methods
 - [x] Declarative marshmallow-based serialization
 - [x] More support for different HTTP methods
+- [x] File upload support on POST
+- [ ] File upload support on PATCH/PUT
 - [ ] Support for user-generated validators
-- [ ] Better file upload support
 - [ ] Better test coverage
 - [ ] Browsable API docs
 
@@ -308,6 +310,14 @@ This will be strictly translated by the API, and acronyms are not considered:
 - `freelance_fulltime == freelanceFulltime`
 - `freelancer_id == freelancerId`
 - `API_strict == apiStrict`
+
+
+File uploads
+------------
+
+File uploads are supported via `POST` using `multipart/form-data` requests.
+
+Support for `PATCH`/`PUT` is on the roadmap.
 
 
 Internal naming

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
 addopts =
     --cov
-    --cov-fail-under 78
+    --cov-fail-under 80
     --cov-report term:skip-covered
     --cov-report html
     --no-cov-on-fail

--- a/tests/models.py
+++ b/tests/models.py
@@ -7,6 +7,7 @@ from django.contrib.auth.models import User
 class Profile(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid4)
 
+    avatar = models.FileField(upload_to="avatars/", blank=True)
     email = models.CharField(max_length=64)
     phone = models.CharField(max_length=64)
 

--- a/tests/serializers.py
+++ b/tests/serializers.py
@@ -21,15 +21,19 @@ class ProfileSerializer(Serializer):
     skills = fields.Nested("RatedSkillSerializer", attribute="ratedskill_set", many=True)
     team = fields.Nested("TeamSerializer")
     tags = fields.Nested("TagSerializer", many=True)
+    user = fields.Nested("UserSerializer")
 
     class Meta:
         fields = [
             "username",
+            "avatar",
             "email",
+            "phone",
             "role",
             "skills",
             "team",
             "tags",
+            "user",
         ]
 
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,4 +1,22 @@
 from datetime import timedelta
+from unittest.mock import patch
+
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test.client import MULTIPART_CONTENT
+
+
+@patch('django.core.files.storage.FileSystemStorage.save')
+def test_profile_create(mock_save, client, db, role, user):
+    avatar = SimpleUploadedFile("avatar.jpg", b"", content_type="image/jpeg")
+    mock_save.return_value = "avatar.jpg"
+    payload = dict(avatar=avatar, role=role.pk, user=user.pk)
+    response = client.post(f"/profiles/", data=payload, content_type=MULTIPART_CONTENT)
+    result = response.json()
+    assert response.status_code == 201, result
+    assert result["avatar"] == "/avatar.jpg"
+    assert result["role"]["id"] == role.pk
+    assert result["role"]["name"] == role.name
+    assert result["user"]["username"] == user.username
 
 
 def test_profile_detail(client, db, profile, user):

--- a/tests/views.py
+++ b/tests/views.py
@@ -4,13 +4,13 @@ from django.db.models import F, Value
 from django.db.models.functions import Concat
 
 from worf.permissions import PublicEndpoint
-from worf.views import DeleteAPI, DetailAPI, DetailUpdateAPI, ListAPI, UpdateAPI
+from worf.views import CreateAPI, DeleteAPI, DetailAPI, ListAPI, UpdateAPI
 
 from tests.models import Profile
 from tests.serializers import ProfileSerializer, UserSerializer
 
 
-class ProfileList(ListAPI):
+class ProfileList(CreateAPI, ListAPI):
     model = Profile
     queryset = Profile.objects.annotate(
         name=Concat("user__first_name", Value(" "), "user__last_name"),
@@ -64,7 +64,7 @@ class UserList(ListAPI):
     ]
 
 
-class UserDetail(DetailUpdateAPI):
+class UserDetail(UpdateAPI, DetailAPI):
     model = User
     serializer = UserSerializer
     permissions = [PublicEndpoint]

--- a/worf/fields.py
+++ b/worf/fields.py
@@ -4,6 +4,11 @@ import marshmallow.fields
 from marshmallow.fields import *  # noqa: F401, F403
 
 
+class File(marshmallow.fields.Field):
+    def _serialize(self, value, attr, obj, **kwargs):
+        return value.url if value.name else None
+
+
 class Nested(marshmallow.fields.Nested):
     def _serialize(self, nested_obj, attr, obj, **kwargs):
         if isinstance(nested_obj, Manager):

--- a/worf/serializers.py
+++ b/worf/serializers.py
@@ -2,6 +2,7 @@ import marshmallow
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
+from django.db.models.fields.files import FieldFile
 
 from worf import fields  # noqa: F401
 from worf.casing import snake_to_camel
@@ -32,6 +33,11 @@ class Serializer(marshmallow.Schema):
     """
 
     OPTIONS_CLASS = SerializerOptions
+
+    TYPE_MAPPING = {
+        **marshmallow.Schema.TYPE_MAPPING,
+        FieldFile: fields.File,
+    }
 
     def __repr__(self):
         return f"<{self.__class__.__name__}()>"

--- a/worf/validators.py
+++ b/worf/validators.py
@@ -218,6 +218,9 @@ class ValidationMixin:
         elif isinstance(field, models.BooleanField):
             self.bundle[key] = self._validate_boolean(key)
 
+        elif isinstance(field, models.FileField):
+            pass  # Django will raise an exception if handled improperly
+
         elif isinstance(field, models.ForeignKey):
             pass  # Django will raise an exception if handled improperly
 


### PR DESCRIPTION
#### What's this PR do?

Adds support for file uploads via POST requests.

Note that `PATCH` and `PUT` are not currently supported; Django doesn't populate `request.FILES` in those methods and supporting them is harder.

We might want to deal the problem out to another library if we can find one, DRF handles this problem within its custom request class.

#### Why is this important, or what issue does this solve?

Allows serializers to `load` `FileField` via multipart file uploads, and `dump` urls to the files.

#### What Worf gif best describes this PR or how it makes you feel?

![worf_data](https://user-images.githubusercontent.com/289531/142026606-fb448a84-4244-4f34-a080-785bcf2c9e5b.gif)

#### Tasks

- [x] This PR increases test coverage
- [x] This PR includes `README` updates reflecting any new features/improvements to the framework