### PR TITLE
Method specific serialization

### DIFF
--- a/worf/views/create.py
+++ b/worf/views/create.py
@@ -3,6 +3,8 @@ from worf.views.base import AbstractBaseAPI
 
 
 class CreateAPI(AssignAttributes, AbstractBaseAPI):
+    create_serializer = None
+
     def create(self):
         instance = self.get_instance()
         self.validate()
@@ -12,6 +14,11 @@ class CreateAPI(AssignAttributes, AbstractBaseAPI):
 
     def get_instance(self):
         return self.model()
+
+    def get_serializer(self):
+        if self.create_serializer and self.request.method == "POST":
+            return self.create_serializer()
+        return super().get_serializer()
 
     def post(self, request, *args, **kwargs):
         new_instance = self.create()

--- a/worf/views/detail.py
+++ b/worf/views/detail.py
@@ -6,8 +6,15 @@ from worf.views.update import UpdateAPI
 
 
 class DetailAPI(FindInstance, AbstractBaseAPI):
+    detail_serializer = None
+
     def get(self, request, *args, **kwargs):
         return self.render_to_response()
+
+    def get_serializer(self):
+        if self.detail_serializer and self.request.method == "GET":
+            return self.detail_serializer()
+        return super().get_serializer()
 
     def serialize(self):
         """Return the model api, used for responses."""

--- a/worf/views/list.py
+++ b/worf/views/list.py
@@ -23,6 +23,7 @@ class ListAPI(AbstractBaseAPI):
     sort_fields = []
     queryset = None
     filter_set = None
+    list_serializer = None
     count = 0
     page_num = 1
     per_page = 25
@@ -166,6 +167,11 @@ class ListAPI(AbstractBaseAPI):
             raise e
 
         return queryset
+
+    def get_serializer(self):
+        if self.list_serializer and self.request.method == "GET":
+            return self.list_serializer()
+        return super().get_serializer()
 
     def paginated_results(self):
         # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ PAGINATION

--- a/worf/views/update.py
+++ b/worf/views/update.py
@@ -4,6 +4,13 @@ from worf.views.base import AbstractBaseAPI
 
 
 class UpdateAPI(AssignAttributes, FindInstance, AbstractBaseAPI):
+    update_serializer = None
+
+    def get_serializer(self):
+        if self.update_serializer and self.request.method in ("PATCH", "PUT"):
+            return self.update_serializer()
+        return super().get_serializer()
+
     def patch(self, request, *args, **kwargs):
         self.update()
         return self.render_to_response()


### PR DESCRIPTION
#### What does this PR do?

Allows views to specify a different serializer for specific methods, e.g. a `CreateSerializer` for `create`.

I don't know how well this fits the bill right now but I think it is probably something we'll need as soon as we attempt to refactor serializers.

#### What issue does this solve?

Serializers can currently only be overridden via `get_serializer`.

#### Where should the reviewer start?

Views / serializers.

#### What Worf gif best describes this PR or how it makes you feel?

#### Checklist

- [x] This PR increases test coverage
- [ ] This PR includes `README` updates reflecting any new features/improvements to the framework