### PR TITLE
Converts empty string to none when field accepts null

### DIFF
--- a/worf/validators.py
+++ b/worf/validators.py
@@ -187,11 +187,11 @@ class ValidationMixin:
             annotation.output_field if annotation else self.model._meta.get_field(key)
         )
 
-        if field.blank and self.bundle[key] == "":
-            pass
+        if field.null and self.bundle[key] in ["", None]:
+            self.bundle[key] = None
 
-        elif field.null and self.bundle[key] is None:
-            pass
+        elif field.blank and self.bundle[key] in ["", None]:
+            self.bundle[key] = ""
 
         elif hasattr(self, f"validate_{key}"):
             self.bundle[key] = getattr(self, f"validate_{key}")(self.bundle[key])


### PR DESCRIPTION
#### What does this PR do?
It converts an empty string to none when the field accepts null

#### What issue does this solve?
If a field has `null=True`, we should be able to make it null by sending an empty string to the API. HTML forms and javascript applications will usually send empty strings when posting to the API. 

#### What Worf gif best describes this PR or how it makes you feel?
[General Klytus from Flash Gordon erasing somebody's mind with a ray]

#### Checklist

- [ ] This PR increases test coverage
- [ ] This PR includes `README` updates reflecting any new features/improvements to the framework
