### PR TITLE
Browsable API

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Table of contents
     - [DetailAPI](#detailapi)
     - [CreateAPI](#createapi)
     - [UpdateAPI](#updateapi)
+  - [Browsable API](#browsable-api)
   - [Bundle loading](#bundle-loading)
   - [Field casing](#field-casing)
   - [File uploads](#file-uploads)
@@ -39,8 +40,19 @@ Table of contents
 Installation
 ------------
 
+Install using pip:
+
 ```sh
 pip install worf
+```
+
+Add `worf` to your `INSTALLED_APPS` setting:
+
+```py
+INSTALLED_APPS = [
+    ...
+    "worf",
+]
 ```
 
 
@@ -55,12 +67,13 @@ Roadmap
 -------
 
 - [x] Abstracting serializers away from model methods
+- [x] Browsable API
 - [x] Declarative marshmallow-based serialization
-- [x] More support for different HTTP methods
 - [x] File upload support
-- [ ] Support for user-generated validators
+- [x] Support for PATCH/PUT methods
 - [ ] Better test coverage
-- [ ] Browsable API docs
+- [ ] Documentation generation
+- [ ] Support for user-generated validators
 
 
 Usage
@@ -271,6 +284,52 @@ class BookDetailAPI(UpdateAPI, DetailAPI):
 Validation of update fields is delegated to the serializer, any fields that are
 writeable should be within the `fields` definition of the serializer, and not
 marked as `dump_only` (read-only).
+
+
+Browsable API
+-------------
+
+Similar to other popular REST frameworks; Worf exposes a browsable API which adds
+syntax highlighting, linkified URLs and supports Django Debug Toolbar.
+
+### Format
+
+To override the default browser behaviour pass `?format=json`.
+
+### Theme
+
+The theme is built with [Tailwind](https://tailwindcss.com/), making it easy to customize the look-and-feel.
+
+For quick and easy branding, there are a couple of Django settings that tweak the navbar:
+
+| Name          | Default  |
+| ------------- | -------- |
+| WORF_API_NAME | Worf API |
+| WORF_API_ROOT | /api/    |
+
+To customize the markup create a template called `worf/api.html` that extends from `worf/base.html`:
+
+```django
+# templates/worf/api.html
+{% extends "worf/base.html" %}
+
+{% block branding %}
+    {{ block.super }}
+    <div>A warrior's drink!</div>
+{% endblock %}
+```
+
+All of the blocks available in the base template can be used in your `api.html`.
+
+| Name     | Description                     |
+| -------- | ------------------------------- |
+| body     | The entire html `<body>`.       |
+| branding | Branding section of the navbar. |
+| script   | JavaScript files for the page.  |
+| style    | CSS stylesheets for the page.   |
+| title    | Title of the page.              |
+
+For more advanced customization you can choose not to have `api.html` extend `base.html`.
 
 
 Bundle loading

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
 addopts =
     --cov
-    --cov-fail-under 80
+    --cov-fail-under 81
     --cov-report term:skip-covered
     --cov-report html
     --no-cov-on-fail

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,11 +34,18 @@ def pytest_configure():
             }
         },
         PASSWORD_HASHERS=["django.contrib.auth.hashers.MD5PasswordHasher"],
+        TEMPLATES = [
+            {
+                "BACKEND": "django.template.backends.django.DjangoTemplates",
+                "APP_DIRS": True,
+            },
+        ],
         TIME_ZONE="UTC",
         USE_I18N=True,
         USE_L10N=True,
         USE_TZ=True,
         STATIC_URL="/static/",
+        WORF_API_NAME="Test API"
     )
 
     django.setup()

--- a/tests/test_browsable_api.py
+++ b/tests/test_browsable_api.py
@@ -1,0 +1,18 @@
+def test_browsable_api(client, db, profile, user):
+    response = client.get(f"/profiles/{profile.pk}/", HTTP_ACCEPT="text/html,image/png")
+
+    content = response.content.decode("UTF-8")
+
+    assert response.status_code == 200, content
+    assert "Test API" in content
+    assert "/api/" in content
+    assert "HTTP" in content
+    assert "200" in content
+    assert "Content-Type" in content
+    assert "application/json" in content
+    assert user.username in content
+
+    assert client.get(f"/profiles/{profile.pk}/", HTTP_ACCEPT="").json()
+    assert client.get(f"/profiles/{profile.pk}/", HTTP_ACCEPT="application/json").json()
+    assert client.get(f"/profiles/{profile.pk}/", HTTP_ACCEPT="text/plain").json()
+    assert client.get(f"/profiles/{profile.pk}/?format=json", HTTP_ACCEPT="text/html").json()

--- a/worf/templates/worf/api.html
+++ b/worf/templates/worf/api.html
@@ -1,0 +1,3 @@
+{% extends "worf/base.html" %}
+
+{# Override this template in your own templates directory to customize #}

--- a/worf/templates/worf/base.html
+++ b/worf/templates/worf/base.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    {% block head %}
+      {% block meta %}
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
+        <meta name="robots" content="none,noarchive"/>
+      {% endblock %}
+
+      <title>{{ api_name }}: {{ request.get_full_path }}</title>
+
+      {% block style %}
+        <link href="https://unpkg.com/tailwindcss@2.2.16/dist/tailwind.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" rel="stylesheet">
+        <link href="https://unpkg.com/prism-themes@1.9.0/themes/prism-atom-dark.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" rel="stylesheet">
+        <link href="https://unpkg.com/prism-js-fold@1.0.1/prism-js-fold.css" crossorigin="anonymous" referrerpolicy="no-referrer" rel="stylesheet">
+        <style>
+          body { background: #131417; color: white; }
+          a { color: #58A6FF; }
+          a:hover { text-decoration: underline; }
+          nav, pre { background: #202126 !important; }
+          strong { font-weight: 500; }
+          pre[class*="language-"], :not(pre) > code[class*="language-"] { border-radius: 0; }
+          .token a { color: #58A6FF; }
+          .token.boolean { color: #FBBF24; }
+          .token.property { color: white; }
+          .token.string { color: #69F5AB; white-space: normal; word-break: break-all; }
+        </style>
+      {% endblock %}
+    {% endblock %}
+  </head>
+
+  <body>
+    {% block body %}
+      {% block nav %}
+        <nav class="p-4">
+          <div class="max-w-5xl mx-auto">
+            {% block branding %}
+              <a href="{{ api_root }}" class="font-medium text-lg text-white" rel="nofollow">
+                {{ api_name }}
+              </a>
+            {% endblock %}
+          </div>
+        </nav>
+      {% endblock %}
+
+      <div class="max-w-5xl mx-auto">
+        <main>
+          {% block content %}
+            <nav class="font-mono break-all my-4 px-4 py-2">
+              <strong>{{ request.method }}</strong> {{ request.get_full_path }}
+            </nav>
+
+            <div class="my-4">
+              <pre class="w-full p-4 overflow-auto"><strong>HTTP {{ response.status_code }} {{ response.status_text }}</strong>{% for key, value in response.headers.items %}
+<strong>{{ key }}:</strong> {{ value }}{% endfor %}
+
+<code class="language-json">{{ content }}</code></pre>
+            </div>
+          {% endblock content %}
+        </main>
+      </div>
+
+      {% block script %}
+        <script src="https://unpkg.com/prismjs@1.25.0" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+        <script src="https://unpkg.com/prismjs@1.25.0/components/prism-json.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+        <script src="https://unpkg.com/prismjs@1.25.0/plugins/keep-markup/prism-keep-markup.js"></script>
+        <script src="https://unpkg.com/prismjs@1.25.0/plugins/autolinker/prism-autolinker.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+        <script src="https://unpkg.com/prism-js-fold@1.0.1" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+        <script>
+          Prism.hooks.add("complete", () => {
+            for (const details of document.getElementsByTagName("details")) {
+              details.open = true
+            }
+          })
+        </script>
+      {% endblock %}
+    {% endblock %}
+  </body>
+</html>


### PR DESCRIPTION
#### What does this PR do?

Adds a html ui when hitting endpoints in a web browser, which presents the output nicely for debugging, and means that Django can inject the debug toolbar.

Also drops worf's gzipmiddleware usage, apps can add that to their middleware stack if they want it, injecting it from within worf makes it difficult to order middlewares correctly so things like debug toolbar will work.

Based loosely on https://www.django-rest-framework.org/topics/browsable-api/

#### What issue does this solve?

I needed django debug toolbar.

#### Where should the reviewer start?

Hit up an api endpoint in Chrome.

#### Screenshots

![](https://user-images.githubusercontent.com/289531/144861565-ea4d9e1d-f15a-4bdd-926b-e9ace41edd84.png)

#### What Worf gif best describes this PR or how it makes you feel?

![Udvr](https://user-images.githubusercontent.com/289531/144861969-245b85c6-46ea-4ecb-8f8a-b4093d61ee36.gif)

#### Checklist

- [x] This PR increases test coverage
- [x] This PR includes `README` updates reflecting any new features/improvements to the framework
  - [x] Template means that `worf` needs adding to `INSTALLED_APPS`
  - [x] There's a couple of new settings for specifying api name/root url; though this could be done via overriding the template
- [x] Might want to support an `?format=json` or similar override