### PR TITLE
 Settings module + Browsable API and debug settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,11 @@ Table of contents
     - [UpdateAPI](#updateapi)
   - [Browsable API](#browsable-api)
   - [Bundle loading](#bundle-loading)
+  - [Debugging](#debugging)
   - [Field casing](#field-casing)
   - [File uploads](#file-uploads)
   - [Internal naming](#internal-naming)
+  - [Settings](#settings)
   - [Credits](#credits)
 
 
@@ -217,8 +219,8 @@ It is not recommended to use this abstract view directly.
 | Name | Type | Default | Description |
 | -- | -- | -- | -- |
 | filters           | dict | {}                  | Pass key/value pairs that you wish to further filter the queryset beyond the `lookup_url_kwarg` |
-| lookup_field      | str  | None                | Use these two settings in tandem in order to filter `get_queryset` based on a URL field. `lookup_url_kwarg` is required if this is set. |
-| lookup_url_kwarg  | str  | None                | Use these two settings in tandem in order to filter `get_queryset` based on a URL field. `lookup_field` is required if this is set. |
+| lookup_field      | str  | None                | Use these two attributes in tandem in order to filter `get_queryset` based on a URL field. `lookup_url_kwarg` is required if this is set. |
+| lookup_url_kwarg  | str  | None                | Use these two attributes in tandem in order to filter `get_queryset` based on a URL field. `lookup_field` is required if this is set. |
 | payload_key       | str  | verbose_name_plural | Use in order to rename the key for the results array |
 | ordering          | list | []                  | Pass a list of fields to default the queryset order by. |
 | filter_fields     | list | []                  | Pass a list of fields to support filtering via query params. |
@@ -292,20 +294,14 @@ Browsable API
 Similar to other popular REST frameworks; Worf exposes a browsable API which adds
 syntax highlighting, linkified URLs and supports Django Debug Toolbar.
 
-### Format
-
-To override the default browser behaviour pass `?format=json`.
+To override the default browser behaviour pass `?format=json`, or [disable the
+feature entirely from settings](#settings).
 
 ### Theme
 
 The theme is built with [Tailwind](https://tailwindcss.com/), making it easy to customize the look-and-feel.
 
-For quick and easy branding, there are a couple of Django settings that tweak the navbar:
-
-| Name          | Default  |
-| ------------- | -------- |
-| WORF_API_NAME | Worf API |
-| WORF_API_ROOT | /api/    |
+For quick and easy branding, there are a couple of [settings that tweak the navbar](#settings).
 
 To customize the markup create a template called `worf/api.html` that extends from `worf/base.html`:
 
@@ -347,6 +343,13 @@ be changed during processing. You may also append or remove attributes to the
 bundle before saving the object via `post`, `patch`, or other methods.
 
 
+Debugging
+---------
+
+Worf exposes the parsed bundle, lookup kwargs, sql and skips some exception handling
+[when in debug mode](#settings).
+
+
 Field casing
 ------------
 
@@ -385,6 +388,18 @@ this codebase for clarity:
 
 - `bundle` is what we send to the backend.
 - `payload` is what the backend returns.
+
+
+Settings
+--------
+
+| Name               | Default        | Description                         |
+| ------------------ | -------------- | ----------------------------------- |
+| WORF_API_NAME      | Worf API       | See [Browsable API](#browsable-api) |
+| WORF_API_ROOT      | /api/          | See [Browsable API](#browsable-api) |
+| WORF_BROWSABLE_API | True           | See [Browsable API](#browsable-api) |
+| WORF_DEBUG         | settings.DEBUG | See [Debugging](#debugging)         |
+
 
 
 Credits

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
 addopts =
     --cov
-    --cov-fail-under 81
+    --cov-fail-under 82
     --cov-report term:skip-covered
     --cov-report html
     --no-cov-on-fail

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,32 +8,20 @@ def pytest_configure():
     from django.conf import settings
 
     settings.configure(
-        SECRET_KEY="secret",
-        DEBUG=True,
-        INSTALLED_APPS=[
-            "django.contrib.admin",
-            "django.contrib.auth",
-            "django.contrib.contenttypes",
-            "django.contrib.sessions",
-            "django.contrib.messages",
-            "django.contrib.staticfiles",
-            "tests",
-            "worf",
-        ],
-        MIDDLEWARE=[
-            "django.middleware.common.CommonMiddleware",
-            "django.contrib.sessions.middleware.SessionMiddleware",
-            "django.contrib.auth.middleware.AuthenticationMiddleware",
-            "django.contrib.messages.middleware.MessageMiddleware",
-        ],
-        ROOT_URLCONF="tests.urls",
         DATABASES={
             "default": {
                 "ENGINE": "django.db.backends.sqlite3",
                 "NAME": "db.sqlite3",
             }
         },
+        INSTALLED_APPS=[
+            "django.contrib.auth",
+            "django.contrib.contenttypes",
+            "tests",
+            "worf",
+        ],
         PASSWORD_HASHERS=["django.contrib.auth.hashers.MD5PasswordHasher"],
+        ROOT_URLCONF="tests.urls",
         TEMPLATES = [
             {
                 "BACKEND": "django.template.backends.django.DjangoTemplates",
@@ -41,11 +29,11 @@ def pytest_configure():
             },
         ],
         TIME_ZONE="UTC",
-        USE_I18N=True,
-        USE_L10N=True,
+        USE_I18N=False,
+        USE_L10N=False,
         USE_TZ=True,
-        STATIC_URL="/static/",
-        WORF_API_NAME="Test API"
+        WORF_API_NAME="Test API",
+        WORF_DEBUG=True,
     )
 
     django.setup()

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -1,0 +1,8 @@
+from worf.conf import settings
+
+
+def test_settings():
+    assert settings.WORF_API_NAME == "Test API"
+    assert settings.WORF_API_ROOT == "/api/"
+    assert settings.WORF_BROWSABLE_API is True
+    assert settings.WORF_DEBUG is True

--- a/worf/conf.py
+++ b/worf/conf.py
@@ -1,0 +1,6 @@
+from importlib import import_module
+
+from django.utils.functional import SimpleLazyObject
+
+
+settings = SimpleLazyObject(lambda: import_module("worf.settings"))

--- a/worf/serializers.py
+++ b/worf/serializers.py
@@ -1,11 +1,11 @@
 import marshmallow
 
-from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.db.models.fields.files import FieldFile
 
 from worf import fields  # noqa: F401
 from worf.casing import snake_to_camel
+from worf.conf import settings
 
 
 class SerializerOptions(marshmallow.SchemaOpts):

--- a/worf/settings.py
+++ b/worf/settings.py
@@ -1,0 +1,9 @@
+from django.conf import settings
+
+
+WORF_API_NAME = getattr(settings, "WORF_API_NAME", "Worf API")
+WORF_API_ROOT = getattr(settings, "WORF_API_ROOT", "/api/")
+
+WORF_BROWSABLE_API = getattr(settings, "WORF_BROWSABLE_API", True)
+
+WORF_DEBUG = getattr(settings, "WORF_DEBUG", settings.DEBUG)

--- a/worf/templates/worf/base.html
+++ b/worf/templates/worf/base.html
@@ -7,7 +7,7 @@
         <meta name="robots" content="none,noarchive"/>
       {% endblock %}
 
-      <title>{{ api_name }}: {{ request.get_full_path }}</title>
+      <title>{{ settings.WORF_API_NAME }}: {{ request.get_full_path }}</title>
 
       {% block style %}
         <link href="https://unpkg.com/tailwindcss@2.2.16/dist/tailwind.min.css" crossorigin="anonymous" referrerpolicy="no-referrer" rel="stylesheet">
@@ -35,8 +35,8 @@
         <nav class="p-4">
           <div class="max-w-5xl mx-auto">
             {% block branding %}
-              <a href="{{ api_root }}" class="font-medium text-lg text-white" rel="nofollow">
-                {{ api_name }}
+              <a href="{{ settings.WORF_API_ROOT }}" class="font-medium text-lg text-white" rel="nofollow">
+                {{ settings.WORF_API_NAME }}
               </a>
             {% endblock %}
           </div>

--- a/worf/validators.py
+++ b/worf/validators.py
@@ -1,12 +1,12 @@
 from datetime import datetime
 from uuid import UUID
 
-from django.conf import settings
 from django.db import models
 from django.core.exceptions import ValidationError
 from django.core.validators import validate_email
 from django.utils.dateparse import parse_datetime
 
+from worf.conf import settings
 from worf.exceptions import NotImplementedInWorfYet
 
 
@@ -167,7 +167,7 @@ class ValidationMixin:
 
         if self.request.method in write_methods and key not in serializer.write():
             message = f"{self.keymap[key]} is not editable"
-            if settings.DEBUG:
+            if settings.WORF_DEBUG:
                 message += f":: {serializer}"
             raise ValidationError(message)
 
@@ -240,7 +240,7 @@ class ValidationMixin:
 
         else:
             message = f"{field.get_internal_type()} has no validation method for {key}"
-            if settings.DEBUG:
+            if settings.WORF_DEBUG:
                 message += f":: Received {self.bundle[key]}"
             raise NotImplementedInWorfYet(message)
             # TODO


### PR DESCRIPTION
Wraps settings up into their own module for visibility, and adds an option to disable browsable api and debug mode.

Also switches testing to exercise debug mode, which seemingly wasn't happening (+0.5% coverage) and fixes a bug where `EmptyResultSet` would throw when trying to render the sql for the debug output.

#### What Worf gif best describes this PR or how it makes you feel?

![](https://www.reactiongifs.com/wp-content/uploads/2013/10/sht.gif)

#### Checklist

- [x] This PR increases test coverage
- [x] This PR includes `README` updates reflecting any new features/improvements to the framework