### PR TITLE
Always set bundle + coerce query params

### DIFF
--- a/worf/views/base.py
+++ b/worf/views/base.py
@@ -204,6 +204,13 @@ class AbstractBaseAPI(APIResponse, ValidationMixin):
             self.bundle[field] = raw_bundle[key]
             self.keymap[field] = key
 
+    def set_bundle_from_request(self, request):
+        if request.method == "GET":
+            self.set_bundle_from_query_string(request)
+            return
+
+        self.set_bundle_from_request_body(request)
+
     def set_bundle_from_query_string(self, request):
         raw_bundle = self.flatten_bundle(parse_qs(request.META["QUERY_STRING"]))
 
@@ -233,7 +240,7 @@ class AbstractBaseAPI(APIResponse, ValidationMixin):
 
         try:
             self._check_permissions()  # only returns 200 or HTTP_EXCEPTIONS
-            self.set_bundle_from_request_body(request)
+            self.set_bundle_from_request(request)
             return handler(request, *args, **kwargs)  # calls self.serialize()
         except HTTP_EXCEPTIONS as e:
             return self.render_to_response(dict(message=e.message), e.status)

--- a/worf/views/base.py
+++ b/worf/views/base.py
@@ -214,7 +214,14 @@ class AbstractBaseAPI(APIResponse, ValidationMixin):
     def set_bundle_from_query_string(self, request):
         raw_bundle = self.flatten_bundle(parse_qs(request.META["QUERY_STRING"]))
 
-        self.set_bundle(raw_bundle)
+        strings = dict(true=True, false=False, null=None)
+
+        coerced_bundle = {
+            key: strings.get(str(value).lower(), value)
+            for key, value in raw_bundle.items()
+        }
+
+        self.set_bundle(coerced_bundle)
 
     def set_bundle_from_request_body(self, request):
         raw_bundle = {}

--- a/worf/views/list.py
+++ b/worf/views/list.py
@@ -86,8 +86,6 @@ class ListAPI(AbstractBaseAPI):
         if not self.filter_fields and not self.search_fields:
             return
 
-        self.set_bundle_from_query_string(self.request)
-
         # Whatever is not q or page as a querystring param will
         # be used for key-value search.
         query = self.bundle.pop("q", "").strip()


### PR DESCRIPTION
#### What does this PR do?

Makes the bundle always available via `GET`, currently only available on list apis, and adds coersion for `true`/`false`/`null` when the bundle is derived from the query string.

Note that this coercion is more strict than elsewhere given we can't assume that `string` isn't the correct type unless it's precisely these values.

We can't assume that `0`/`1` are bools, or that a numeric string should be an `int`, but we can reasonably assume that no one wants a string `"true"`/`"false"`/`"null"` when passing query params.

#### What issue does this solve?

The bundle provides a selection of conveniences over using the request QueryDicts directly, so needs to be available always, life also gets a lot easier when query string bools are bools.

This makes it easier for developers to patch in arbitrary API tweaks like swapping out a serializer when a query parameter like `?nextgen=true` is passed.

#### Checklist

- [x] This PR increases test coverage