### PR TITLE
Strip lookup field validation

### DIFF
--- a/worf/lookups.py
+++ b/worf/lookups.py
@@ -6,8 +6,6 @@ class FindInstance:
     def get_instance(self):
         self.lookup_kwargs = {self.lookup_field: self.kwargs[self.lookup_url_kwarg]}
 
-        self.validate_lookup_field_values()
-
         if not hasattr(self, "instance"):
             self.instance = self.get_queryset().get(**self.lookup_kwargs)
 

--- a/worf/validators.py
+++ b/worf/validators.py
@@ -126,11 +126,10 @@ class ValidationMixin:
             raise ValidationError(f"Expected numeric, got {value}")
 
     def validate_uuid(self, value):
-        if value is None:
-            raise ValidationError(f"Expected UUID, got {value}")
         try:
+            assert value is not None
             return UUID(str(value))
-        except (TypeError, ValueError):
+        except (AssertionError, TypeError, ValueError):
             raise ValidationError(f"Expected UUID, got {value}")
 
     def validate_email(self, value):

--- a/worf/views/list.py
+++ b/worf/views/list.py
@@ -74,8 +74,6 @@ class ListAPI(AbstractBaseAPI):
                 {self.lookup_field: self.kwargs[self.lookup_url_kwarg]}
             )
 
-        self.validate_lookup_field_values()
-
     def set_search_lookup_kwargs(self):
         """
         Set generic lookup kwargs based on q and additional GET params.


### PR DESCRIPTION
Strip lookup field validation that makes assumptions about fields used and lookups supported.

#### What issue does this solve?

Django doesn't need lookup values validating, the framework already coerces/validates them internally, and this prevents users from using lookup fields other than ints and uuids.

#### What Worf gif best describes this PR or how it makes you feel?

![tumblr_62ac2c2dd6344dba9b4cadf89cb24d05_bd929b72_400](https://user-images.githubusercontent.com/289531/146530327-5a965b54-23ca-4775-a844-2d672653b1d2.gif)

#### Checklist

- [x] This PR increases test coverage