### PR TITLE
Serializer field ordering

### DIFF
--- a/worf/serializers.py
+++ b/worf/serializers.py
@@ -12,12 +12,14 @@ class SerializerOptions(marshmallow.SchemaOpts):
     def __init__(self, meta, **kwargs):
         super().__init__(meta, **kwargs)
 
-        defaults = getattr(settings, "WORF_SERIALIZER_DEFAULT_OPTIONS", {})
-        fields = getattr(meta, "fields", [])
-        writable = getattr(meta, "writable", [])
+        defaults = settings.WORF_SERIALIZER_DEFAULT_OPTIONS
+        defaults["ordered"] = defaults.get("ordered", True)
 
         for key, value in defaults.items():
             setattr(self, key, getattr(meta, key, value))
+
+        fields = getattr(meta, "fields", [])
+        writable = getattr(meta, "writable", [])
 
         if writable:
             self.dump_only = list(set(fields) - set(writable))

--- a/worf/settings.py
+++ b/worf/settings.py
@@ -7,3 +7,7 @@ WORF_API_ROOT = getattr(settings, "WORF_API_ROOT", "/api/")
 WORF_BROWSABLE_API = getattr(settings, "WORF_BROWSABLE_API", True)
 
 WORF_DEBUG = getattr(settings, "WORF_DEBUG", settings.DEBUG)
+
+WORF_SERIALIZER_DEFAULT_OPTIONS = getattr(
+    settings, "WORF_SERIALIZER_DEFAULT_OPTIONS", {}
+)


### PR DESCRIPTION
Sort fields output in the json by the order in the serializer meta fields list, this was already the default in worf but for some reason it doesn't always work, this defaults it harder, while still allowing it to be customized per serializer or via settings.

https://marshmallow.readthedocs.io/en/stable/quickstart.html#ordering-output