### PR TITLE
Support unique field validation

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
 addopts =
     --cov
-    --cov-fail-under 82
+    --cov-fail-under 83
     --cov-report term:skip-covered
     --cov-report html
     --no-cov-on-fail

--- a/tests/views.py
+++ b/tests/views.py
@@ -48,11 +48,11 @@ class ProfileDetail(DeleteAPI, UpdateAPI, DetailAPI):
         try:
             assert value == "(555) 555-5555"
         except AssertionError:
-            raise ValidationError("{value} is not a valid phone number")
+            raise ValidationError("Field phone is not a valid phone number")
         return "+5555555555"
 
 
-class UserList(ListAPI):
+class UserList(CreateAPI, ListAPI):
     model = User
     ordering = ["pk"]
     serializer = UserSerializer(only=[

--- a/worf/assigns.py
+++ b/worf/assigns.py
@@ -80,6 +80,8 @@ class AssignAttributes:
             raise ValidationError(f"Invalid {self.keymap[key]}") from e
 
     def validate(self):
+        instance = self.get_instance()
+
         for key in self.bundle.keys():
             self.validate_bundle(key)
 
@@ -87,3 +89,9 @@ class AssignAttributes:
 
             if self.bundle[key] is None and not field.null:
                 raise ValidationError(f"Invalid {self.keymap[key]}")
+
+            if field.unique:
+                other_records = self.model.objects.exclude(pk=instance.pk)
+
+                if other_records.filter(**{key: self.bundle[key]}).exists():
+                    raise ValidationError(f"Field {self.keymap[key]} must be unique")

--- a/worf/testing.py
+++ b/worf/testing.py
@@ -7,25 +7,28 @@ JSON_CONTENT = "application/json"
 
 
 class ApiClient(Client):
-    def generic_multipart(self, method, path, data=None, content_type=None, **kwargs):
-        content_type = content_type or self._guess_content_type(data)
+    def generic(self, method, path, data=None, content_type=None, **kwargs):
+        content_type = content_type or guess_content_type(data)
         data = self._encode_multipart(data, content_type)
-        return self.generic(method, path, data, content_type, **kwargs)
+        return super().generic(method, path, data, content_type, **kwargs)
 
-    patch = partialmethod(generic_multipart, "PATCH")
-    post = partialmethod(generic_multipart, "POST")
-    put = partialmethod(generic_multipart, "PUT")
-
-    def _contains_files(self, data):
-        return any(isinstance(value, File) for value in data.values())
+    delete = partialmethod(generic, "DELETE")
+    patch = partialmethod(generic, "PATCH")
+    post = partialmethod(generic, "POST")
+    put = partialmethod(generic, "PUT")
 
     def _encode_multipart(self, data, content_type):
         post_data = self._encode_json({} if data is None else data, content_type)
         return self._encode_data(post_data, content_type)
 
-    def _guess_content_type(self, data):
-        return (
-            MULTIPART_CONTENT
-            if isinstance(data, dict) and self._contains_files(data)
-            else JSON_CONTENT
-        )
+
+def guess_content_type(data):
+    return MULTIPART_CONTENT if should_multipart(data) else JSON_CONTENT
+
+
+def has_files(data):
+    return any(isinstance(value, File) for value in data.values())
+
+
+def should_multipart(data):
+    return isinstance(data, dict) and has_files(data)


### PR DESCRIPTION
Validate that unique fields are not being set to existing values, so that validation errors occur instead of db integrity errors.

Also refactors the tests and test client a bit, because duplicating tests for `patch` and `put` was getting tedious.

![](https://i.imgflip.com/1lgrvi.gif)

Note that this doesn't cater for `unique_together`, which would probably need custom validation anyway.

- [x] This PR increases test coverage to 83%