### PR TITLE
Strip legacy serialization and improve fields query param

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Validators
 
 Validation handling can be found in `worf.validators`.
 
-The basics come from `ValidationMixin` which `AbstractBaseAPI` inherits from, it
+The basics come from `ValidateFields` which `AbstractBaseAPI` inherits from, it
 performs some coercion on `self.bundle`, potentially resulting in a different
 bundle than what was originally passed to the view.
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
 addopts =
     --cov
-    --cov-fail-under 88
+    --cov-fail-under 90
     --cov-report term:skip-covered
     --cov-report html
     --no-cov-on-fail

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,3 +1,4 @@
+from hashlib import md5
 from uuid import uuid4
 
 from django.db import models
@@ -26,31 +27,19 @@ class Profile(models.Model):
 
     recovery_email = models.EmailField(blank=True, max_length=320, null=True)
     recovery_phone = models.CharField(blank=True, max_length=32, null=True)
+    resume = models.FileField(upload_to="resumes/", blank=True)
 
     last_active = models.DateField(blank=True, null=True)
     created_at = models.DateTimeField(blank=True, null=True)
 
-    def api(self):
-        return dict(id=self.id, email=self.email, phone=self.phone)
+    def get_avatar_url(self):
+        return self.avatar.url if self.avatar else self.get_gravatar_url()
 
-    def api_update_fields(self):
-        return [
-            "id",
-            "email",
-            "phone",
+    def get_gravatar_hash(self):
+        return md5(self.user.email.lower().encode()).hexdigest()
 
-            "boolean",
-            "integer",
-            "json",
-            "positive_integer",
-            "slug",
-            "small_integer",
-
-            "recovery_email",
-
-            "last_active",
-            "created_at",
-        ]
+    def get_gravatar_url(self, default="identicon", size=512):
+        return f"https://www.gravatar.com/avatar/{self.get_gravatar_hash()}?d={default}&s={size}"
 
 
 class Role(models.Model):

--- a/tests/serializers.py
+++ b/tests/serializers.py
@@ -7,6 +7,7 @@ class UserSerializer(Serializer):
 
     class Meta:
         fields = [
+            "id",
             "username",
             "last_login",
             "date_joined",
@@ -15,8 +16,9 @@ class UserSerializer(Serializer):
 
 
 class ProfileSerializer(Serializer):
-    username = fields.Function(lambda obj: obj.user.username)
-    email = fields.Function(lambda obj: obj.user.email)
+    username = fields.String(attribute="user.username")
+    email = fields.String(attribute="user.email")
+    avatar = fields.File(lambda profile: profile.get_avatar_url())
     role = fields.Nested("RoleSerializer")
     skills = fields.Nested("RatedSkillSerializer", attribute="ratedskill_set", many=True)
     team = fields.Nested("TeamSerializer")
@@ -25,21 +27,53 @@ class ProfileSerializer(Serializer):
 
     class Meta:
         fields = [
+            "id",
             "username",
-            "avatar",
             "email",
             "phone",
+            "avatar",
+            "boolean",
+            "integer",
+            "json",
+            "positive_integer",
+            "slug",
+            "small_integer",
+            "recovery_email",
+            "resume",
             "role",
             "skills",
             "team",
             "tags",
             "user",
+            "last_active",
+            "created_at",
+        ]
+        writable = [
+            "id",
+            "email",
+            "phone",
+            "avatar",
+            "boolean",
+            "integer",
+            "json",
+            "positive_integer",
+            "slug",
+            "small_integer",
+            "recovery_email",
+            "resume",
+            "role",
+            "skills",
+            "team",
+            "tags",
+            "user",
+            "last_active",
+            "created_at",
         ]
 
 
 class RatedSkillSerializer(Serializer):
-    id = fields.Function(lambda obj: obj.skill.id)
-    name = fields.Function(lambda obj: obj.skill.name)
+    id = fields.Integer(attribute="skill.id")
+    name = fields.String(attribute="skill.name")
 
     class Meta:
         fields = ["id", "name", "rating"]

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -34,7 +34,6 @@ def profile_view_fixture(db, now, profile_factory):
     ))
     view.request = RequestFactory().patch(f"/{uuid}/")
     view.kwargs = dict(id=str(uuid))
-    view.serializer = None
     return view
 
 

--- a/tests/views.py
+++ b/tests/views.py
@@ -56,6 +56,7 @@ class UserList(CreateAPI, ListAPI):
     model = User
     ordering = ["pk"]
     serializer = UserSerializer(only=[
+        "id",
         "username",
         "date_joined",
         "email",
@@ -78,5 +79,5 @@ class UserList(CreateAPI, ListAPI):
 
 class UserDetail(UpdateAPI, DetailAPI):
     model = User
-    serializer = UserSerializer
+    serializer = UserSerializer(exclude=["date_joined"])
     permissions = [PublicEndpoint]

--- a/worf/exceptions.py
+++ b/worf/exceptions.py
@@ -1,8 +1,7 @@
 class HTTPException(Exception):
     def __init__(self, message=None):
         super().__init__(message)
-        if message is not None:
-            self.message = message
+        self.message = message or self.message
 
 
 class HTTP400(HTTPException):
@@ -47,9 +46,13 @@ class NamingThingsError(ValueError):
     pass
 
 
-class PermissionsException(Exception):
+class PermissionsError(Exception):
     pass
 
 
 class NotImplementedInWorfYet(NotImplementedError):
+    pass
+
+
+class SerializerError(ValueError):
     pass

--- a/worf/fields.py
+++ b/worf/fields.py
@@ -1,22 +1,47 @@
-import marshmallow.fields
+from marshmallow import fields, utils
+from marshmallow.exceptions import ValidationError
 from marshmallow.fields import *  # noqa: F401, F403
 
 from django.db.models import Manager
 
 
-class File(marshmallow.fields.Field):
+class File(fields.Field):
+    _CHECK_ATTRIBUTE = False
+
+    def __init__(self, serialize=None, deserialize=None, **kwargs):
+        super().__init__(**kwargs)
+        self.serialize_func = serialize and utils.callable_or_raise(serialize)
+        self.deserialize_func = deserialize and utils.callable_or_raise(deserialize)
+
     def _serialize(self, value, attr, obj, **kwargs):
+        if self.serialize_func:
+            return self._call_or_raise(self.serialize_func, obj, attr)
         return value.url if value.name else None
 
+    # Worf serializers are not really used for deserialization yet, so no cover
 
-class Nested(marshmallow.fields.Nested):
+    def _deserialize(self, value, attr, data, **kwargs):  # pragma: no cover
+        if self.deserialize_func:
+            return self._call_or_raise(self.deserialize_func, value, attr)
+        return value
+
+    def _call_or_raise(self, func, value, attr):
+        if len(utils.get_func_args(func)) > 1:  # pragma: no cover
+            if self.parent.context is None:
+                msg = f"No context available for Function field {attr!r}"
+                raise ValidationError(msg)
+            return func(value, self.parent.context)
+        return func(value)
+
+
+class Nested(fields.Nested):
     def _serialize(self, nested_obj, attr, obj, **kwargs):
         if isinstance(nested_obj, Manager):
             nested_obj = nested_obj.all()
         return super()._serialize(nested_obj, attr, obj, **kwargs)
 
 
-class Pluck(marshmallow.fields.Pluck):
+class Pluck(fields.Pluck):
     def _serialize(self, nested_obj, attr, obj, **kwargs):
         if isinstance(nested_obj, Manager):
             nested_obj = nested_obj.all()

--- a/worf/validators.py
+++ b/worf/validators.py
@@ -10,7 +10,7 @@ from worf.conf import settings
 from worf.exceptions import NotImplementedInWorfYet
 
 
-class ValidationMixin:
+class ValidateFields:
     boolean_values = {
         "1": True,
         "0": False,
@@ -159,10 +159,11 @@ class ValidationMixin:
 
         We expect to set a fully validated bundle keys and values.
         """
-        serializer = self.get_serializer()
+        serializer = self.load_serializer()
+        write_fields = list(serializer.load_fields.keys())
         write_methods = ("PATCH", "POST", "PUT")
 
-        if self.request.method in write_methods and key not in serializer.write():
+        if self.request.method in write_methods and key not in write_fields:
             message = f"{self.keymap[key]} is not editable"
             if settings.WORF_DEBUG:
                 message += f":: {serializer}"

--- a/worf/views/create.py
+++ b/worf/views/create.py
@@ -5,7 +5,7 @@ from worf.views.base import AbstractBaseAPI
 class CreateAPI(AssignAttributes, AbstractBaseAPI):
     create_serializer = None
 
-    def create(self):
+    def create(self, *args, **kwargs):
         self.instance = self.new_instance()
         self.validate()
         self.save(self.instance, self.bundle)
@@ -14,11 +14,13 @@ class CreateAPI(AssignAttributes, AbstractBaseAPI):
 
     def get_serializer(self):
         if self.create_serializer and self.request.method == "POST":
-            return self.create_serializer(context=self.get_serializer_context())
+            return self.create_serializer(**self.get_serializer_kwargs())
         return super().get_serializer()
 
     def new_instance(self):
         return self.model()
 
-    def post(self, request, *args, **kwargs):
-        return self.render_to_response(self.get_serializer().read(self.create()), 201)
+    def post(self, *args, **kwargs):
+        instance = self.create(*args, **kwargs)
+        result = self.load_serializer().dump(instance)
+        return self.render_to_response(result, 201)

--- a/worf/views/delete.py
+++ b/worf/views/delete.py
@@ -2,9 +2,9 @@ from worf.views.base import AbstractBaseAPI
 
 
 class DeleteAPI(AbstractBaseAPI):
-    def delete(self, request, *args, **kwargs):
-        self.destroy()
+    def delete(self, *args, **kwargs):
+        self.destroy(*args, **kwargs)
         return self.render_to_response("", 204)
 
-    def destroy(self):
+    def destroy(self, *args, **kwargs):
         self.get_instance().delete()

--- a/worf/views/detail.py
+++ b/worf/views/detail.py
@@ -1,5 +1,3 @@
-from django.core.exceptions import ImproperlyConfigured
-
 from worf.lookups import FindInstance
 from worf.views.base import AbstractBaseAPI
 from worf.views.update import UpdateAPI
@@ -8,24 +6,17 @@ from worf.views.update import UpdateAPI
 class DetailAPI(FindInstance, AbstractBaseAPI):
     detail_serializer = None
 
-    def get(self, request, *args, **kwargs):
+    def get(self, *args, **kwargs):
         return self.render_to_response()
 
     def get_serializer(self):
         if self.detail_serializer and self.request.method == "GET":
-            return self.detail_serializer(context=self.get_serializer_context())
+            return self.detail_serializer(**self.get_serializer_kwargs())
         return super().get_serializer()
 
     def serialize(self):
-        """Return the model api, used for responses."""
-        serializer = self.get_serializer()
-        payload = serializer.read(self.get_instance())
-        if not isinstance(payload, dict):
-            raise ImproperlyConfigured(f"{serializer} did not return a dictionary")
-        return payload
+        return self.load_serializer().dump(self.get_instance())
 
 
 class DetailUpdateAPI(UpdateAPI, DetailAPI):
-    def patch(self, request, *args, **kwargs):
-        self.update()
-        return self.get(request)
+    pass

--- a/worf/views/update.py
+++ b/worf/views/update.py
@@ -8,18 +8,18 @@ class UpdateAPI(AssignAttributes, FindInstance, AbstractBaseAPI):
 
     def get_serializer(self):
         if self.update_serializer and self.request.method in ("PATCH", "PUT"):
-            return self.update_serializer(context=self.get_serializer_context())
+            return self.update_serializer(**self.get_serializer_kwargs())
         return super().get_serializer()
 
-    def patch(self, request, *args, **kwargs):
-        self.update()
+    def patch(self, *args, **kwargs):
+        self.update(*args, **kwargs)
         return self.render_to_response()
 
-    def put(self, request, *args, **kwargs):
-        self.update()
+    def put(self, *args, **kwargs):
+        self.update(*args, **kwargs)
         return self.render_to_response()
 
-    def update(self):
+    def update(self, *args, **kwargs):
         instance = self.get_instance()
         self.validate()
         self.save(instance, self.bundle)


### PR DESCRIPTION
- Strip support for legacy serializers
- Pass request + args + kwargs to view CRUD methods
- Support fields param on detail endpoints in addition to lists
- Apply fields param filtering in the serialization step
- Serializer `__call__` now honors only/exclude rules from its predecessors