### PR TITLE
Switch permissions to classes and raise rather than return

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,15 +179,8 @@ WORF_SERIALIZER_DEFAULT_OPTIONS = {
 Permissions
 -----------
 
-Permissions functions can be found in `worf.permissions`.
-
-These functions extend the API View, so they require `self` to be defined as a
-parameter. This is done in order to allow access to `self.request` during
-permission testing.
-
-If permissions should be granted, functions should return `int(200)`.
-
-If permissions fail, they should return an `HTTPException`
+Permissions are callable classes that can be found in `worf.permissions`, they're passed
+the `request` and `kwargs` from the view, and raise an exception if the check fails.
 
 
 Validators

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
 addopts =
     --cov
-    --cov-fail-under 90
+    --cov-fail-under 92
     --cov-report term:skip-covered
     --cov-report html
     --no-cov-on-fail

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,8 +19,13 @@ def pytest_configure():
         INSTALLED_APPS=[
             "django.contrib.auth",
             "django.contrib.contenttypes",
+            "django.contrib.sessions",
             "tests",
             "worf",
+        ],
+        MIDDLEWARE=[
+            "django.contrib.sessions.middleware.SessionMiddleware",
+            "django.contrib.auth.middleware.AuthenticationMiddleware",
         ],
         PASSWORD_HASHERS=["django.contrib.auth.hashers.MD5PasswordHasher"],
         ROOT_URLCONF="tests.urls",
@@ -36,7 +41,7 @@ def pytest_configure():
         USE_L10N=False,
         USE_TZ=True,
         WORF_API_NAME="Test API",
-        WORF_DEBUG=True,
+        WORF_DEBUG=False,
     )
 
     django.setup()
@@ -80,7 +85,7 @@ def client_fixture():
 def now_fixture():
     from django.utils import timezone
 
-    return timezone.now()
+    return timezone.now
 
 
 @pytest.fixture(name="url")

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -5,4 +5,4 @@ def test_settings():
     assert settings.WORF_API_NAME == "Test API"
     assert settings.WORF_API_ROOT == "/api/"
     assert settings.WORF_BROWSABLE_API is True
-    assert settings.WORF_DEBUG is True
+    assert settings.WORF_DEBUG is False

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,17 +1,13 @@
 from django.urls import path
 
-from tests.views import (
-    ProfileDetail,
-    ProfileList,
-    ProfileListSubSet,
-    UserDetail,
-    UserList,
-)
+from tests import views
 
 urlpatterns = [
-    path("profiles/", ProfileList.as_view()),
-    path("profiles/subset/", ProfileListSubSet.as_view()),
-    path("profiles/<str:id>/", ProfileDetail.as_view()),
-    path("users/", UserList.as_view()),
-    path("users/<str:id>/", UserDetail.as_view()),
+    path("profiles/", views.ProfileList.as_view()),
+    path("profiles/subset/", views.ProfileListSubSet.as_view()),
+    path("profiles/<uuid:id>/", views.ProfileDetail.as_view()),
+    path("profiles/<uuid:id>/staff/", views.StaffDetail.as_view()),
+    path("user/", views.UserSelf.as_view()),
+    path("users/", views.UserList.as_view()),
+    path("users/<int:id>/", views.UserDetail.as_view()),
 ]

--- a/worf/exceptions.py
+++ b/worf/exceptions.py
@@ -42,6 +42,12 @@ class HTTP422(HTTPException):
 HTTP_EXCEPTIONS = (HTTP400, HTTP401, HTTP404, HTTP409, HTTP410, HTTP420, HTTP422)
 
 
+class AuthenticationError(Exception):
+    def __init__(self, message):
+        super().__init__(message)
+        self.message = message
+
+
 class NamingThingsError(ValueError):
     pass
 
@@ -55,4 +61,6 @@ class NotImplementedInWorfYet(NotImplementedError):
 
 
 class SerializerError(ValueError):
-    pass
+    def __init__(self, message):
+        super().__init__(message)
+        self.message = message

--- a/worf/filters.py
+++ b/worf/filters.py
@@ -15,12 +15,12 @@ class AnnotatedModelFilterSet(ModelFilterSet):
             state = self._build_state()
 
             for name in self.queryset.query.annotations.keys():
-                if name in self.Meta.exclude or name in filters:
+                if name in self.Meta.exclude or name in filters:  # pragma: no cover
                     continue
 
                 try:
                     annotation_filter = self._build_annotation_filter(name, state)
-                except SkipFilter:
+                except SkipFilter:  # pragma: no cover
                     continue
 
                 if annotation_filter is not None:
@@ -31,11 +31,11 @@ class AnnotatedModelFilterSet(ModelFilterSet):
     def _build_annotation_filter(self, name, state):
         field = self.queryset.query.annotations.get(name).output_field
 
-        if isinstance(field, RelatedField):
+        if isinstance(field, RelatedField):  # pragma: no cover
             if not self.Meta.allow_related:
                 raise SkipFilter
             return self._build_filterset_from_related_field(name, field)
-        elif isinstance(field, ForeignObjectRel):
+        elif isinstance(field, ForeignObjectRel):  # pragma: no cover
             if not self.Meta.allow_related_reverse:
                 raise SkipFilter
             return self._build_filterset_from_reverse_field(name, field)

--- a/worf/permissions.py
+++ b/worf/permissions.py
@@ -1,17 +1,22 @@
 from worf.exceptions import HTTP401, HTTP404
 
 
-def Authenticated(self, request):
-    if not request.user.is_authenticated:
-        return HTTP401()
-    return 200
+class Authenticated:
+    def __call__(self, request, **kwargs):
+        if request.user.is_authenticated:
+            return
+
+        raise HTTP401()
 
 
-def Staff(self, request):
-    if not request.user.is_authenticated or not request.user.is_staff:
-        return HTTP404()
-    return 200
+class PublicEndpoint:
+    def __call__(self, request, **kwargs):
+        pass
 
 
-def PublicEndpoint(self, request):
-    return 200
+class Staff:
+    def __call__(self, request, **kwargs):
+        if request.user.is_authenticated and request.user.is_staff:
+            return
+
+        raise HTTP404()

--- a/worf/views/list.py
+++ b/worf/views/list.py
@@ -36,19 +36,19 @@ class ListAPI(AbstractBaseAPI):
 
         codepath = self.codepath
 
-        if not isinstance(self.filters, dict):
+        if not isinstance(self.filters, dict):  # pragma: no cover
             raise ImproperlyConfigured(f"{codepath}.filters must be type: dict")
 
-        if not isinstance(self.ordering, list):
+        if not isinstance(self.ordering, list):  # pragma: no cover
             raise ImproperlyConfigured(f"{codepath}.ordering must be type: list")
 
-        if not isinstance(self.filter_fields, list):
+        if not isinstance(self.filter_fields, list):  # pragma: no cover
             raise ImproperlyConfigured(f"{codepath}.filter_fields must be type: list")
 
-        if not isinstance(self.search_fields, (dict, list)):
+        if not isinstance(self.search_fields, (dict, list)):  # pragma: no cover
             raise ImproperlyConfigured(f"{codepath}.search_fields must be type: list")
 
-        if not isinstance(self.sort_fields, list):
+        if not isinstance(self.sort_fields, list):  # pragma: no cover
             raise ImproperlyConfigured(f"{codepath}.sort_fields must be type: list")
 
         # generate a default filterset if a custom one was not provided


### PR DESCRIPTION
- AuthenticationError for raising from views to trigger a 401
- Partial refactor of permissions, raise exceptions, no return value
- Move away from binding permissions to views, pass kwargs in
- Bump coverage to 92%