### PR TITLE
(Improvement) Support assigning relations via custom lookup fields

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,6 +46,7 @@ def pytest_configure():
         RoleFactory,
         SkillFactory,
         TagFactory,
+        TaskFactory,
         TeamFactory,
         UserFactory,
     )
@@ -54,6 +55,7 @@ def pytest_configure():
     register(RoleFactory, "role")
     register(SkillFactory, "skill")
     register(TagFactory, "tag")
+    register(TaskFactory, "task")
     register(TeamFactory, "team")
     register(UserFactory, "user")
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -3,7 +3,7 @@ from factory.django import DjangoModelFactory
 
 from django.contrib.auth.models import User
 
-from tests.models import Profile, Role, Skill, Tag, Team
+from tests.models import Profile, Role, Skill, Tag, Task, Team
 
 
 class ProfileFactory(DjangoModelFactory):
@@ -39,6 +39,13 @@ class TagFactory(DjangoModelFactory):
 
     class Meta:
         model = Tag
+
+
+class TaskFactory(DjangoModelFactory):
+    name = factory.Sequence(lambda i: f"Task {i}")
+
+    class Meta:
+        model = Task
 
 
 class TeamFactory(DjangoModelFactory):

--- a/tests/models.py
+++ b/tests/models.py
@@ -23,6 +23,7 @@ class Profile(models.Model):
     role = models.ForeignKey("Role", on_delete=models.CASCADE)
     team = models.ForeignKey("Team", blank=True, null=True, on_delete=models.SET_NULL)
     skills = models.ManyToManyField("Skill", through="RatedSkill")
+    tasks = models.ManyToManyField("Task")
     tags = models.ManyToManyField("Tag")
 
     recovery_email = models.EmailField(blank=True, max_length=320, null=True)
@@ -73,6 +74,14 @@ class RatedSkill(models.Model):
 
 class Tag(models.Model):
     name = models.CharField(max_length=200)
+
+
+class Task(models.Model):
+    custom_id = models.UUIDField(default=uuid4)
+    name = models.CharField(max_length=200)
+
+    class Api:
+        lookup_field = "custom_id"
 
 
 class Team(models.Model):

--- a/tests/serializers.py
+++ b/tests/serializers.py
@@ -23,6 +23,7 @@ class ProfileSerializer(Serializer):
     skills = fields.Nested("SkillSerializer", attribute="ratedskill_set", many=True)
     team = fields.Nested("TeamSerializer")
     tags = fields.Pluck("TagSerializer", "name", many=True)
+    tasks = fields.Pluck("TaskSerializer", "name", many=True)
     user = fields.Nested("UserSerializer")
 
     class Meta:
@@ -44,6 +45,7 @@ class ProfileSerializer(Serializer):
             "skills",
             "team",
             "tags",
+            "tasks",
             "user",
             "last_active",
             "created_at",
@@ -65,6 +67,7 @@ class ProfileSerializer(Serializer):
             "skills",
             "team",
             "tags",
+            "tasks",
             "user",
             "last_active",
             "created_at",
@@ -85,6 +88,13 @@ class SkillSerializer(Serializer):
 
 
 class TagSerializer(Serializer):
+    class Meta:
+        fields = ["id", "name"]
+
+
+class TaskSerializer(Serializer):
+    id = fields.UUID(attribute="custom_id")
+
     class Meta:
         fields = ["id", "name"]
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -200,6 +200,16 @@ def test_profile_update_m2m_can_be_empty(client, db, method, profile, tag):
 
 
 @pytest.mark.parametrize("method", ["PATCH", "PUT"])
+def test_profile_update_m2m_lookup_field(client, db, method, profile, task):
+    payload = dict(tasks=[task.custom_id])
+    response = client.generic(method, f"/profiles/{profile.pk}/", payload)
+    result = response.json()
+    assert response.status_code == 200, result
+    assert len(result["tasks"]) == 1
+    assert result["tasks"][0] == task.name
+
+
+@pytest.mark.parametrize("method", ["PATCH", "PUT"])
 def test_profile_update_m2m_is_not_nullable(client, db, method, profile, tag):
     response = client.generic(method, f"/profiles/{profile.pk}/", dict(tags=None))
     result = response.json()


### PR DESCRIPTION
Allows models to specify a custom lookup field to use when assigning relations:

```py
class User(Model):
    class Api:
        lookup_field = "profile__uuid"
```