### PR TITLE
(Improvement) Support custom actions via ActionAPI

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,7 +5,7 @@ indent_style = space
 indent_size = 2
 end_of_line = lf
 charset = utf-8
-max_line_length = 80
+max_line_length = 88
 trim_trailing_whitespace = true
 insert_final_newline = true
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
 addopts =
     --cov
-    --cov-fail-under 92
+    --cov-fail-under 93.5
     --cov-report term:skip-covered
     --cov-report html
     --no-cov-on-fail

--- a/tests/models.py
+++ b/tests/models.py
@@ -3,6 +3,7 @@ from uuid import uuid4
 
 from django.contrib.auth.models import User
 from django.db import models
+from django.utils.timezone import now
 
 
 class Profile(models.Model):
@@ -33,6 +34,12 @@ class Profile(models.Model):
     last_active = models.DateField(blank=True, null=True)
     created_at = models.DateTimeField(blank=True, null=True)
 
+    is_subscribed = models.BooleanField(blank=True, null=True)
+    subscribed_at = models.DateTimeField(blank=True, null=True)
+    subscribed_by = models.ForeignKey(
+        User, blank=True, null=True, on_delete=models.SET_NULL
+    )
+
     def get_avatar_url(self):
         return self.avatar.url if self.avatar else self.get_gravatar_url()
 
@@ -41,6 +48,18 @@ class Profile(models.Model):
 
     def get_gravatar_url(self, default="identicon", size=512):
         return f"https://www.gravatar.com/avatar/{self.get_gravatar_hash()}?d={default}&s={size}"
+
+    def subscribe(self, user=None):
+        self.is_subscribed = True
+        self.subscribed_at = now()
+        self.subscribed_by = user
+        self.save()
+
+    def unsubscribe(self):
+        self.is_subscribed = False
+        self.subscribed_at = None
+        self.subscribed_by = None
+        self.save()
 
 
 class Role(models.Model):

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1,0 +1,53 @@
+from tests import parametrize
+
+
+def test_action_model_func(user_client, profile):
+    response = user_client.put(f"/profiles/{profile.pk}/unsubscribe/")
+    result = response.json()
+    assert response.status_code == 200, result
+    profile.refresh_from_db()
+    assert profile.is_subscribed is False
+    assert profile.subscribed_at is None
+    assert profile.subscribed_by is None
+
+
+def test_action_model_func_with_user_argument(user_client, profile, user):
+    response = user_client.put(f"/profiles/{profile.pk}/subscribe/")
+    result = response.json()
+    assert response.status_code == 200, result
+    profile.refresh_from_db()
+    assert profile.is_subscribed is True
+    assert profile.subscribed_at is not None
+    assert profile.subscribed_by == user
+
+
+def test_action_view_func(user_client, profile, user):
+    response = user_client.put(f"/profiles/{profile.pk}/resubscribe/")
+    result = response.json()
+    assert response.status_code == 200, result
+    profile.refresh_from_db()
+    assert profile.is_subscribed is True
+    assert profile.subscribed_at is not None
+    assert profile.subscribed_by == user
+
+
+def test_invalid_action(user_client, profile):
+    response = user_client.put(f"/profiles/{profile.pk}/invalid-action/")
+    result = response.json()
+    assert response.status_code == 400, result
+    assert result["message"] == "Invalid action: invalid-action"
+
+
+def test_invalid_arguments(user_client, profile):
+    kwargs = dict(text="I love newsletters")
+    response = user_client.put(f"/profiles/{profile.pk}/subscribe/", kwargs)
+    result = response.json()
+    assert response.status_code == 400, result
+    message = "Invalid arguments: subscribe() got an unexpected keyword argument 'text'"
+    assert result["message"] == message
+
+
+@parametrize("method", ["GET", "DELETE", "PATCH", "POST"])
+def test_invalid_method(user_client, method, profile):
+    response = user_client.generic(method, f"/profiles/{profile.pk}/subscribe/")
+    assert response.status_code == 405

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,16 @@
+from tests import parametrize
+from worf import exceptions
+
+
+@parametrize(
+    dict(e=exceptions.ActionError("test")),
+    dict(e=exceptions.AuthenticationError("test")),
+    dict(e=exceptions.DataConflict("test")),
+    dict(e=exceptions.NamingThingsError("test")),
+    dict(e=exceptions.NotFound("test")),
+    dict(e=exceptions.PermissionsError("test")),
+    dict(e=exceptions.SerializerError("test")),
+    dict(e=exceptions.WorfError("test")),
+)
+def test_exception(e):
+    assert e.message == str(e) == "test"

--- a/tests/test_permissions.py
+++ b/tests/test_permissions.py
@@ -2,7 +2,7 @@ import pytest
 
 from django.contrib.auth.models import AnonymousUser, User
 
-from worf.exceptions import HTTP401, HTTP404
+from worf.exceptions import AuthenticationError, NotFound
 from worf.permissions import Authenticated, PublicEndpoint, Staff
 
 
@@ -11,7 +11,7 @@ def test_authenticated(db, rf):
     request = rf.get("/")
     request.user = AnonymousUser()
 
-    with pytest.raises(HTTP401):
+    with pytest.raises(AuthenticationError):
         assert permission(request) is None
 
     request.user = User.objects.create(username="test", password="test")
@@ -32,12 +32,12 @@ def test_staff(db, rf):
     request = rf.get("/")
     request.user = AnonymousUser()
 
-    with pytest.raises(HTTP404):
+    with pytest.raises(NotFound):
         assert permission(request) is None
 
     request.user = User.objects.create(username="test", password="test")
 
-    with pytest.raises(HTTP404):
+    with pytest.raises(NotFound):
         assert permission(request) is None
 
     request.user.is_staff = True

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -18,7 +18,7 @@ def test_profile_not_found(client, db, profile, user):
     response = client.get(f"/profiles/{uuid4()}/")
     result = response.json()
     assert response.status_code == 404, result
-    assert result["message"] == "Not Found"
+    assert result["message"] == "Not found"
 
 
 def test_profile_delete(client, db, profile, user):
@@ -33,6 +33,14 @@ def test_profile_list(client, db, profile, user):
     assert response.status_code == 200, result
     assert len(result["profiles"]) == 1
     assert result["profiles"][0]["username"] == user.username
+
+
+@parametrize("page", [-1, 0, 1, 2])
+def test_profile_list_pages(client, db, page):
+    response = client.get("/profiles/", dict(page=page))
+    result = response.json()
+    assert response.status_code == 200, result
+    assert len(result["profiles"]) == 0
 
 
 def test_profile_list_filters(client, db, profile, url, user):
@@ -115,13 +123,6 @@ def test_profile_list_negated__icontains__filters(client, db, profile, url, user
 @parametrize("url_params__array_format", ["comma", "repeat"])
 def test_profile_list_not_in_filters(client, db, profile, url, user):
     response = client.get(url("/profiles/", {"name__in!": [user.name, "Din Djarin"]}))
-    result = response.json()
-    assert response.status_code == 200, result
-    assert len(result["profiles"]) == 0
-
-
-def test_profile_list_subset_filters(client, db, profile, url, user):
-    response = client.get(url("/profiles/subset/", {"name": user.name}))
     result = response.json()
     assert response.status_code == 200, result
     assert len(result["profiles"]) == 0
@@ -290,21 +291,21 @@ def test_profile_update_m2m_through_required_fields(client, db, method, profile,
 
 
 def test_staff_detail(admin_client, profile, user):
-    response = admin_client.get(f"/profiles/{profile.pk}/staff/")
+    response = admin_client.get(f"/staff/{profile.pk}/")
     result = response.json()
     assert response.status_code == 200, result
     assert result["username"] == user.username
 
 
 def test_staff_detail_is_not_found_for_user(user_client, profile, user):
-    response = user_client.get(f"/profiles/{profile.pk}/staff/")
+    response = user_client.get(f"/staff/{profile.pk}/")
     result = response.json()
     assert response.status_code == 404, result
-    assert result["message"] == "Not Found"
+    assert result["message"] == "Not found"
 
 
 def test_staff_detail_is_unauthorized_for_guest(client, db, profile, user):
-    response = client.get(f"/profiles/{profile.pk}/staff/")
+    response = client.get(f"/staff/{profile.pk}/")
     result = response.json()
     assert response.status_code == 401, result
     assert result["message"] == "Unauthorized"

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -4,9 +4,9 @@ from tests import views
 
 urlpatterns = [
     path("profiles/", views.ProfileList.as_view()),
-    path("profiles/subset/", views.ProfileListSubSet.as_view()),
     path("profiles/<uuid:id>/", views.ProfileDetail.as_view()),
-    path("profiles/<uuid:id>/staff/", views.StaffDetail.as_view()),
+    path("profiles/<uuid:id>/<str:action>/", views.ProfileDetail.as_view()),
+    path("staff/<uuid:id>/", views.StaffDetail.as_view()),
     path("user/", views.UserSelf.as_view()),
     path("users/", views.UserList.as_view()),
     path("users/<int:id>/", views.UserDetail.as_view()),

--- a/tests/views.py
+++ b/tests/views.py
@@ -7,7 +7,7 @@ from tests.models import Profile
 from tests.serializers import ProfileSerializer, UserSerializer
 from worf.exceptions import AuthenticationError
 from worf.permissions import Authenticated, PublicEndpoint, Staff
-from worf.views import CreateAPI, DeleteAPI, DetailAPI, ListAPI, UpdateAPI
+from worf.views import ActionAPI, CreateAPI, DeleteAPI, DetailAPI, ListAPI, UpdateAPI
 
 
 class ProfileList(CreateAPI, ListAPI):
@@ -35,14 +35,20 @@ class ProfileList(CreateAPI, ListAPI):
     ]
 
 
-class ProfileListSubSet(ProfileList):
-    queryset = ProfileList.queryset.none()
-
-
-class ProfileDetail(DeleteAPI, UpdateAPI, DetailAPI):
+class ProfileDetail(ActionAPI, DeleteAPI, UpdateAPI, DetailAPI):
     model = Profile
     serializer = ProfileSerializer
     permissions = [PublicEndpoint]
+    actions = [
+        "resubscribe",
+        "subscribe",
+        "unsubscribe",
+    ]
+
+    def resubscribe(self, request, *args, **kwargs):
+        profile = self.get_instance()
+        profile.subscribe(user=request.user)
+        return profile
 
     def validate_phone(self, value):
         try:

--- a/worf/exceptions.py
+++ b/worf/exceptions.py
@@ -1,66 +1,41 @@
-class HTTPException(Exception):
-    def __init__(self, message=None):
-        super().__init__(message)
-        self.message = message or self.message
+from dataclasses import dataclass
 
 
-class HTTP400(HTTPException):
-    message = "Bad Request"
-    status = 400
+@dataclass(frozen=True)
+class WorfError(Exception):
+    message: str
 
 
-class HTTP401(HTTPException):
-    message = "Unauthorized"
-    status = 401
+@dataclass(frozen=True)
+class ActionError(WorfError):
+    message: str
 
 
-class HTTP404(HTTPException):
-    message = "Not Found"
-    status = 404
+@dataclass(frozen=True)
+class AuthenticationError(WorfError):
+    message: str = "Unauthorized"
 
 
-class HTTP409(HTTPException):
-    message = "Conflict"
-    status = 409
+@dataclass(frozen=True)
+class DataConflict(WorfError):
+    message: str = "Conflict"
 
 
-class HTTP410(HTTPException):
-    message = "Gone"
-    status = 410
+@dataclass(frozen=True)
+class NamingThingsError(WorfError, ValueError):
+    message: str
 
 
-class HTTP420(HTTPException):
-    message = "Enhance Your Calm"
-    status = 420
+@dataclass(frozen=True)
+class NotFound(WorfError):
+    message: str = "Not found"
 
 
-class HTTP422(HTTPException):
-    message = "Unprocessable Entity"
-    status = 422
+@dataclass(frozen=True)
+class PermissionsError(WorfError):
+    message: str
 
 
-HTTP_EXCEPTIONS = (HTTP400, HTTP401, HTTP404, HTTP409, HTTP410, HTTP420, HTTP422)
-
-
-class AuthenticationError(Exception):
-    def __init__(self, message):
-        super().__init__(message)
-        self.message = message
-
-
-class NamingThingsError(ValueError):
-    pass
-
-
-class PermissionsError(Exception):
-    pass
-
-
-class NotImplementedInWorfYet(NotImplementedError):
-    pass
-
-
-class SerializerError(ValueError):
-    def __init__(self, message):
-        super().__init__(message)
-        self.message = message
+@dataclass(frozen=True)
+class SerializerError(WorfError, ValueError):
+    message: str

--- a/worf/permissions.py
+++ b/worf/permissions.py
@@ -1,12 +1,10 @@
-from worf.exceptions import HTTP401, HTTP404
+from worf.exceptions import AuthenticationError, NotFound
 
 
 class Authenticated:
     def __call__(self, request, **kwargs):
-        if request.user.is_authenticated:
-            return
-
-        raise HTTP401()
+        if not request.user.is_authenticated:
+            raise AuthenticationError()
 
 
 class PublicEndpoint:
@@ -16,7 +14,5 @@ class PublicEndpoint:
 
 class Staff:
     def __call__(self, request, **kwargs):
-        if request.user.is_authenticated and request.user.is_staff:
-            return
-
-        raise HTTP404()
+        if not request.user.is_authenticated or not request.user.is_staff:
+            raise NotFound()

--- a/worf/validators.py
+++ b/worf/validators.py
@@ -7,7 +7,6 @@ from django.db import models
 from django.utils.dateparse import parse_datetime
 
 from worf.conf import settings
-from worf.exceptions import NotImplementedInWorfYet
 
 
 class ValidateFields:
@@ -149,7 +148,7 @@ class ValidateFields:
 
         @param key: the model attribute to check against.
 
-        @raise NotImplementedInWorfYet: If the field type is not currently supported
+        @raise NotImplementedError: If the field type is not currently supported
         @raise ValidationError: If this is a write and `key` is not serializer editable
         @raise ValidationError: If a value fails to pass validation
 
@@ -244,4 +243,4 @@ class ValidateFields:
         message = f"{field.get_internal_type()} has no validation method for {key}"
         if settings.WORF_DEBUG:
             message += f":: Received {self.bundle[key]}"
-        raise NotImplementedInWorfYet(message)
+        raise NotImplementedError(message)

--- a/worf/views/__init__.py
+++ b/worf/views/__init__.py
@@ -1,3 +1,4 @@
+from worf.views.action import ActionAPI  # noqa
 from worf.views.base import AbstractBaseAPI, APIResponse  # noqa
 from worf.views.create import CreateAPI  # noqa
 from worf.views.delete import DeleteAPI  # noqa

--- a/worf/views/action.py
+++ b/worf/views/action.py
@@ -1,0 +1,33 @@
+from worf.exceptions import ActionError
+from worf.lookups import FindInstance
+from worf.views.base import AbstractBaseAPI
+
+
+class ActionAPI(FindInstance, AbstractBaseAPI):
+    actions = []
+
+    def dispatch(self, request, *args, **kwargs):
+        if "action" in kwargs and request.method != "PUT":
+            return self.http_method_not_allowed(request, *args, **kwargs)
+        return super().dispatch(request, *args, **kwargs)
+
+    def perform_action(self, request, *args, **kwargs):
+        action = kwargs["action"].replace("-", "_")
+        if action not in self.actions:
+            raise ActionError(f"Invalid action: {kwargs['action']}")
+        instance = self.get_instance()
+        if hasattr(self, action):
+            return getattr(self, action)(request, **self.bundle, user=request.user)
+        try:
+            getattr(instance, action)(**self.bundle, user=request.user)
+        except TypeError as e:
+            if "unexpected keyword argument 'user'" not in str(e):
+                raise ActionError(f"Invalid arguments: {e}")
+            getattr(instance, action)(**self.bundle)
+        return instance
+
+    def put(self, request, *args, **kwargs):
+        if "action" in kwargs:
+            self.perform_action(request, *args, **kwargs)
+            return self.render_to_response()
+        return super().put(request, *args, **kwargs)

--- a/worf/views/detail.py
+++ b/worf/views/detail.py
@@ -4,15 +4,8 @@ from worf.views.update import UpdateAPI
 
 
 class DetailAPI(FindInstance, AbstractBaseAPI):
-    detail_serializer = None
-
     def get(self, *args, **kwargs):
         return self.render_to_response()
-
-    def get_serializer(self):
-        if self.detail_serializer and self.request.method == "GET":
-            return self.detail_serializer(**self.get_serializer_kwargs())
-        return super().get_serializer()
 
 
 class DetailUpdateAPI(UpdateAPI, DetailAPI):


### PR DESCRIPTION
Support custom actions via PUT requests that proxy to model or view methods.

1. Inherit `ActionAPI` in the view
2. Define some `actions` on the view (a list of strings)
3. Register the action route (last, it's wildcard)

```py
path("profiles/<uuid:id>/", views.ProfileDetail.as_view()),
path("profiles/<uuid:id>/<str:action>/", views.ProfileDetail.as_view()),
```

`ActionAPI` will call a corresponding view method if one exists, this is handy if more complex validation needs to happen before the action is run, otherwise, the model method is called directly.

The bundle and `request.user` are passed through via kwargs to the action be it a model or view action, primarily this is so that model actions can store the user acting upon the instance.

![](https://thumbs.gfycat.com/CavernousNiftyAmethystgemclam-size_restricted.gif)

Action names are defined in `snake_case` but passing `kebab-case` via the URL is supported.

`ActionAPI` can be used with or without `DetailAPI` and `UpdateAPI`.