### PR TITLE
(Improvement) Switch out PermissionsError for reraise with extended message

### DIFF
--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -9,7 +9,6 @@ from worf import exceptions
     dict(e=exceptions.FieldError("test")),
     dict(e=exceptions.NamingThingsError("test")),
     dict(e=exceptions.NotFound("test")),
-    dict(e=exceptions.PermissionsError("test")),
     dict(e=exceptions.WorfError("test")),
 )
 def test_exception(e):

--- a/worf/exceptions.py
+++ b/worf/exceptions.py
@@ -32,10 +32,5 @@ class NotFound(WorfError):
 
 
 @dataclass(frozen=True)
-class PermissionsError(WorfError):
-    message: str
-
-
-@dataclass(frozen=True)
 class FieldError(WorfError, ValueError):
     message: str

--- a/worf/renderers.py
+++ b/worf/renderers.py
@@ -8,13 +8,14 @@ from worf.shortcuts import field_list
 
 def browsable_response(request, response, status_code, view):
     template = "worf/api.html"
-    serializer = view.get_serializer()
+    serializer = hasattr(view, "bundle") and view.get_serializer()
 
-    include = field_list(view.bundle.get("include", []))
-    search = field_list(view.bundle.get("search", []), delimiter="__")
+    bundle = getattr(view, "bundle", {})
+    include = field_list(bundle.get("include", []))
+    search = field_list(bundle.get("search", []), delimiter="__")
 
     filter_fields = [
-        (transform_field(field), bool(field in view.bundle))
+        (transform_field(field), bool(field in bundle))
         for field in getattr(view, "filter_fields", [])
     ]
     include_fields = [
@@ -42,11 +43,11 @@ def browsable_response(request, response, status_code, view):
             (
                 "Search",
                 sorted(search_fields),
-                len(search or search_fields) if view.bundle.get("q") else 0,
+                len(search or search_fields) if bundle.get("q") else 0,
             ),
         ],
         lookup_kwargs=getattr(view, "lookup_kwargs", {}),
-        payload=view.bundle,
+        payload=bundle,
         response=response,
         serializer=serializer,
         serializer_name=type(serializer).__name__,

--- a/worf/views/__init__.py
+++ b/worf/views/__init__.py
@@ -3,5 +3,6 @@ from worf.views.base import AbstractBaseAPI, APIResponse  # noqa: F401
 from worf.views.create import CreateAPI  # noqa: F401
 from worf.views.delete import DeleteAPI  # noqa: F401
 from worf.views.detail import DetailAPI, DetailUpdateAPI  # noqa: F401
+from worf.views.errors import NotFound  # noqa: F401
 from worf.views.list import ListAPI, ListCreateAPI  # noqa: F401
 from worf.views.update import UpdateAPI  # noqa: F401

--- a/worf/views/errors.py
+++ b/worf/views/errors.py
@@ -1,0 +1,11 @@
+from django.utils.decorators import method_decorator
+from django.views.decorators.csrf import csrf_exempt
+
+from worf import exceptions
+from worf.views.base import AbstractBaseAPI
+
+
+@method_decorator(csrf_exempt, name="dispatch")
+class NotFound(AbstractBaseAPI):
+    def perform_dispatch(self, *args, **kwargs):
+        raise exceptions.NotFound()


### PR DESCRIPTION
Switches away from overriding the intended permission exception with the generic PermissionsError when `WORF_DEBUG=True`.

This means that 500's no longer happen in dev and instead the expected 4xx error is returned but with a longer message to aid debugging.