### PR TITLE
(Improvement) Switch to dj-url-filter and drop Python 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
 
     strategy:
       matrix:
-        python: [3.8, 3.9, "3.10", 3.11]
+        python: [3.9, "3.10", 3.11]
         django: [3.2, "4.0", 4.1]
         exclude:
           - python: 3.11

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -29,6 +29,14 @@
             ],
             "version": "==1.5.2"
         },
+        "dj-url-filter": {
+            "hashes": [
+                "sha256:43773a8a9c169e0b5539b916cb55693695a20c13ad0aeaa7a8ffd7f964ebd2a9",
+                "sha256:80cb8d71cbc296e10475b41d58ab8e172e9e8370ae08e5737bf68b9d7061a07e"
+            ],
+            "markers": "python_version >= '3.9' and python_version < '4.0'",
+            "version": "==0.4.4"
+        },
         "django": {
             "hashes": [
                 "sha256:18ba8efa36b69cfcd4b670d0fa187c6fe7506596f0ababe580e16909bcdec121",
@@ -36,13 +44,6 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==3.2.16"
-        },
-        "django-url-filter": {
-            "hashes": [
-                "sha256:12d66e4ff0150e10fd4efd1ec292a06a2cec6311ec2e4bd1fc99b2fea18e2a7b",
-                "sha256:fdc882d45c72546d07657ef1074ad7a5490807d990b1618eae1873bfd0b4c4d1"
-            ],
-            "version": "==0.3.15"
         },
         "enum-compat": {
             "hashes": [
@@ -133,7 +134,7 @@
                 "sha256:2d63a8c573417bae338962d4b9b06fbc6080f74ecd955a092849e1e65c717bd2",
                 "sha256:412d3f259dab4077d0e7f0c11f50f650cc7d10db905d98f6520a95a18049658a"
             ],
-            "markers": "python_version >= '3.7'",
+            "markers": "python_version >= '3.7.0'",
             "version": "==1.7.4"
         },
         "black": {
@@ -170,7 +171,7 @@
                 "sha256:085f7f33c15bd408dd9b17a4ad77c577db66d76203e5984b1bd59baeee948b2a",
                 "sha256:0d03255c47eb9bd2f26aa9bb7f2107732e7e8fe195ca2f64709fcf3b0a4a085c"
             ],
-            "markers": "python_version >= '3.7'",
+            "markers": "python_version >= '3.7.0'",
             "version": "==5.0.1"
         },
         "build": {
@@ -263,7 +264,7 @@
                 "sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845",
                 "sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f"
             ],
-            "markers": "python_full_version >= '3.6.0'",
+            "markers": "python_version >= '3.6.0'",
             "version": "==2.1.1"
         },
         "click": {
@@ -271,7 +272,7 @@
                 "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e",
                 "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"
             ],
-            "markers": "python_version >= '3.7'",
+            "markers": "python_version >= '3.7.0'",
             "version": "==8.1.3"
         },
         "colorama": {
@@ -386,7 +387,7 @@
                 "sha256:33995a6753c30b7f577febfc2c50411fec6aac7f7ffeb7c4cfe5991072dcf9e6",
                 "sha256:5e1de4d849fee02c63b040a4a3fd567f4ab104defd8a5511fbbc24a8a017efbc"
             ],
-            "markers": "python_version >= '3.7'",
+            "markers": "python_version >= '3.7.0'",
             "version": "==0.19"
         },
         "exceptiongroup": {
@@ -418,7 +419,7 @@
                 "sha256:2d5443724f640ce07658ca8ca8bbd40d26b58914e63eec6549727869aa67e2cc",
                 "sha256:c2a2ff9dd8dfd991109b517ab98d5cb465e857acb45f6b643a0e284a9eb2cc76"
             ],
-            "markers": "python_version >= '3.7'",
+            "markers": "python_version >= '3.7.0'",
             "version": "==15.3.4"
         },
         "flake8": {
@@ -472,7 +473,7 @@
                 "sha256:6eb990b69df4e15bad899ea868dc46572c3f75339735663b81de79b06f17eb9a",
                 "sha256:c286cf298426064079ed96a9e4a9d39e7f3e9bf15ba60701e95f5492f28415c7"
             ],
-            "markers": "python_version >= '3.7'",
+            "markers": "python_version >= '3.7.0'",
             "version": "==4.0.10"
         },
         "gitpython": {
@@ -480,7 +481,7 @@
                 "sha256:769c2d83e13f5d938b7688479da374c4e3d49f71549aaf462b646db9602ea6f8",
                 "sha256:cd455b0000615c60e286208ba540271af9fe531fa6a87cc590a7298785ab2882"
             ],
-            "markers": "python_version >= '3.7'",
+            "markers": "python_version >= '3.7.0'",
             "version": "==3.1.30"
         },
         "idna": {
@@ -496,7 +497,7 @@
                 "sha256:7efb448ec9a5e313a57655d35aa54cd3e01b7e1fbcf72dce1bf06119420f5bad",
                 "sha256:e354bedeb60efa6affdcc8ae121b73544a7aa74156d047311948f6d711cd378d"
             ],
-            "markers": "python_version >= '3.7'",
+            "markers": "python_version < '3.12'",
             "version": "==6.0.0"
         },
         "inflection": {
@@ -527,7 +528,7 @@
                 "sha256:2353de3288bc6b82120752201c6b1c1a14b058267fa424ed5ce5984e3b922158",
                 "sha256:89559fa5c1d3c34eff6f631ad80bb21f378dbcbb35dd161fd2c6b93f5be2f98a"
             ],
-            "markers": "python_version >= '3.7'",
+            "markers": "python_version >= '3.7.0'",
             "version": "==3.2.3"
         },
         "jeepney": {
@@ -543,7 +544,7 @@
                 "sha256:771ed2a91909389ed6148631de678f82ddc73737d85a927f382a8a1b157898cd",
                 "sha256:ba2e15a9b35e21908d0aaf4e0a47acc52d6ae33444df0da2b49d41a46ef6d678"
             ],
-            "markers": "python_version >= '3.7'",
+            "markers": "python_version >= '3.7.0'",
             "version": "==23.13.1"
         },
         "markdown-it-py": {
@@ -551,7 +552,7 @@
                 "sha256:93de681e5c021a432c63147656fe21790bc01231e0cd2da73626f1aa3ac0fe27",
                 "sha256:cf7e59fed14b5ae17c0006eff14a2d9a00ed5f3a846148153899a0224e2c07da"
             ],
-            "markers": "python_version >= '3.7'",
+            "markers": "python_version >= '3.7.0'",
             "version": "==2.1.0"
         },
         "mccabe": {
@@ -567,7 +568,7 @@
                 "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8",
                 "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"
             ],
-            "markers": "python_version >= '3.7'",
+            "markers": "python_version >= '3.7.0'",
             "version": "==0.1.2"
         },
         "more-itertools": {
@@ -575,7 +576,7 @@
                 "sha256:250e83d7e81d0c87ca6bd942e6aeab8cc9daa6096d12c5308f3f92fa5e5c1f41",
                 "sha256:5a6257e40878ef0520b1803990e3e22303a41b5714006c32a3fd8304b26ea1ab"
             ],
-            "markers": "python_version >= '3.7'",
+            "markers": "python_version >= '3.7.0'",
             "version": "==9.0.0"
         },
         "mypy-extensions": {
@@ -598,7 +599,7 @@
                 "sha256:3c95343af8b756205e2aba76e843ba9520a24dd84f68c22b9f93251507509dd6",
                 "sha256:56200de4077d9d0791465aa9095a01d421861e405b5096955051deefd697d6f6"
             ],
-            "markers": "python_version >= '3.7'",
+            "markers": "python_version >= '3.7.0'",
             "version": "==0.10.3"
         },
         "pbr": {
@@ -630,7 +631,7 @@
                 "sha256:83c8f6d04389165de7c9b6f0c682439697887bca0aa2f1c87ef1826be3584490",
                 "sha256:e1fea1fe471b9ff8332e229df3cb7de4f53eeea4998d3b6bfff542115e998bd2"
             ],
-            "markers": "python_version >= '3.7'",
+            "markers": "python_version >= '3.7.0'",
             "version": "==2.6.2"
         },
         "pluggy": {
@@ -704,7 +705,7 @@
                 "sha256:283c11acd6b928d2f6a7c73fa0d01cb2bdc5f07c57a2eeb6e83d5e56b97976f8",
                 "sha256:f271b298b97f5955d53fb12b72c1fb1948c22c1a6b70b315c54cedaca0264ef5"
             ],
-            "markers": "python_version >= '3.7'",
+            "markers": "python_version >= '3.7.0'",
             "version": "==1.0.0"
         },
         "pytest": {
@@ -825,7 +826,7 @@
                 "sha256:cd653186dfc73055656f090f227f5cb22a046d7f71a841dfa305f55c9a513273",
                 "sha256:f67a16caedfa71eef48a31b39708637a6f4664c4394801a7b0d6432d13907343"
             ],
-            "markers": "python_version >= '3.7'",
+            "markers": "python_version >= '3.7.0'",
             "version": "==37.3"
         },
         "requests": {
@@ -833,7 +834,7 @@
                 "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983",
                 "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"
             ],
-            "markers": "python_version >= '3.7' and python_version < '4'",
+            "markers": "python_version < '4' and python_version >= '3.7.0'",
             "version": "==2.28.1"
         },
         "requests-toolbelt": {
@@ -849,7 +850,7 @@
                 "sha256:50b1502b60e289cb37883f3dfd34532b8873c7de9f49bb546641ce9cbd256ebd",
                 "sha256:97aacf9dbd4bfd829baad6e6309fa6573aaf1be3f6fa735c8ab05e46cecb261c"
             ],
-            "markers": "python_version >= '3.7'",
+            "markers": "python_version >= '3.7.0'",
             "version": "==2.0.0"
         },
         "rich": {
@@ -857,7 +858,7 @@
                 "sha256:12b1d77ee7edf251b741531323f0d990f5f570a4e7c054d0bfb59fb7981ad977",
                 "sha256:3aa9eba7219b8c575c6494446a59f702552efe1aa261e7eeb95548fa586e1950"
             ],
-            "markers": "python_full_version >= '3.7.0'",
+            "markers": "python_version >= '3.7.0'",
             "version": "==13.0.0"
         },
         "secretstorage": {
@@ -969,7 +970,7 @@
                 "sha256:83a28fcb75844b5c0cdaf5aa4003c2d728c77e05f5aeabe8e95e56727005fbaa",
                 "sha256:a7a22e05929290a67401440b39690ae6563279bced5f314609d9d03798f56766"
             ],
-            "markers": "python_version >= '3.7'",
+            "markers": "python_version >= '3.7.0'",
             "version": "==3.11.0"
         }
     }

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ INSTALLED_APPS = [
 Requirements
 ------------
 
-- Python (3.8, 3.9, 3.10, 3.11)
+- Python (3.9, 3.10, 3.11)
 - Django (3.2, 4.0, 4.1)
 
 

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,6 @@ setup(
         "Framework :: Django",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
@@ -52,10 +51,10 @@ setup(
     include_package_data=True,
     install_requires=[
         "Django>=3.0.0,<4.2",
-        "django-url-filter>=0.3.15",
+        "dj-url-filter>=0.4.2",
         "marshmallow>=3.18.0",
     ],
     packages=find_packages(exclude=["tests*"]),
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     zip_safe=False,
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,7 +37,6 @@ def pytest_configure():
         ],
         TIME_ZONE="UTC",
         USE_I18N=False,
-        USE_L10N=False,
         USE_TZ=True,
         WORF_API_NAME="Test API",
         WORF_DEBUG=False,


### PR DESCRIPTION
Swaps out `django-url-filter` for the `dj-url-filter` fork that has active maintainers and Django 4 support.

Also drops support for Python 3.8 given `dj-url-filter` doesn't support it.

https://github.com/miki725/django-url-filter/issues/113
https://github.com/enjoy2000/django-url-filter