### PR TITLE
(Improvement) Swap out ActionAPI regex paths for explicit paths

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,10 +24,10 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
+python = "^3.9"
 dj-url-filter = "^0.4.4"
 django = ">=3.0.0,<4.2"
 marshmallow = "^3.18"
-python = "^3.9"
 
 [tool.poetry.group.dev.dependencies]
 build = "^0.10.0"
@@ -48,13 +48,13 @@ isort = "^5.12.0"
 [tool.poetry.group.test.dependencies]
 coverage = "^7.1.0"
 factory-boy = "^3.2.1"
+pytest = "^7.2.1"
 pytest-cov = "^4.0.0"
 pytest-django = "^4.5.2"
 pytest-factoryboy = "2.1.0"
+pytest-kwparametrize = "^0.0.3"
 pytest-watch = "^4.2.0"
 pytest-xdist = "^3.1.0"
-pytest = "^7.2.1"
-pytest-kwparametrize = "^0.0.3"
 
 [tool.black]
 line-length = 88

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -32,10 +32,10 @@ def test_action_view_func(user_client, profile, user):
 
 
 def test_invalid_action(user_client, profile):
-    response = user_client.put(f"/profiles/{profile.pk}/invalid-action/")
+    response = user_client.put(f"/profiles/{profile.pk}/destroy/")
     result = response.json()
-    assert response.status_code == 400, result
-    assert result["message"] == "Invalid action: invalid-action"
+    assert response.status_code == 404, result
+    assert result["message"] == "Not found"
 
 
 def test_invalid_arguments(user_client, profile):

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -7,6 +7,7 @@ from worf import exceptions
     dict(e=exceptions.AuthenticationError("test")),
     dict(e=exceptions.DataConflict("test")),
     dict(e=exceptions.FieldError("test")),
+    dict(e=exceptions.MethodNotAllowed("test")),
     dict(e=exceptions.NamingThingsError("test")),
     dict(e=exceptions.NotFound("test")),
     dict(e=exceptions.WorfError("test")),

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,13 +1,13 @@
-from django.urls import path
-
 from tests import views
+from worf.urls import api
+from worf.views import errors
 
 urlpatterns = [
-    path("profiles/", views.ProfileList.as_view()),
-    path("profiles/<uuid:id>/", views.ProfileDetail.as_view()),
-    path("profiles/<uuid:id>/<str:action>/", views.ProfileDetail.as_view()),
-    path("staff/<uuid:id>/", views.StaffDetail.as_view()),
-    path("user/", views.UserSelf.as_view()),
-    path("users/", views.UserList.as_view()),
-    path("users/<int:id>/", views.UserDetail.as_view()),
+    api("profiles/", views.ProfileList),
+    api("profiles/<uuid:id>/", views.ProfileDetail),
+    api("staff/<uuid:id>/", views.StaffDetail),
+    api("user/", views.UserSelf),
+    api("users/", views.UserList),
+    api("users/<int:id>/", views.UserDetail),
+    api("<path:any>/", errors.NotFound),
 ]

--- a/worf/exceptions.py
+++ b/worf/exceptions.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 
 @dataclass(frozen=True)
@@ -19,6 +19,12 @@ class AuthenticationError(WorfError):
 @dataclass(frozen=True)
 class DataConflict(WorfError):
     message: str = "Conflict"
+
+
+@dataclass(frozen=True)
+class MethodNotAllowed(WorfError):
+    message: str = "Method not allowed"
+    allowed_methods: list[str] = field(default_factory=list)
 
 
 @dataclass(frozen=True)

--- a/worf/renderers.py
+++ b/worf/renderers.py
@@ -6,7 +6,7 @@ from worf.conf import settings
 from worf.shortcuts import field_list
 
 
-def browsable_response(request, response, status_code, view):
+def browsable_response(request, response, status_code, view, **kwargs):
     template = "worf/api.html"
     serializer = hasattr(view, "bundle") and view.get_serializer()
 
@@ -56,14 +56,14 @@ def browsable_response(request, response, status_code, view):
         view_name=type(view).__name__,
     )
 
-    response = TemplateResponse(request, template, context=context)
+    response = TemplateResponse(request, template, context=context, **kwargs)
     response.status_code = status_code
     response.render()
 
     return response
 
 
-def render_response(request, data, status_code, view):
+def render_response(request, data, status_code, view, **kwargs):
     is_browsable = (
         settings.WORF_BROWSABLE_API
         and "text/html" in request.headers.get("Accept", "")
@@ -71,15 +71,17 @@ def render_response(request, data, status_code, view):
     )
 
     response = (
-        JsonResponse(data, json_dumps_params=dict(indent=2 if is_browsable else 0))
+        JsonResponse(
+            data, json_dumps_params=dict(indent=2 if is_browsable else 0), **kwargs
+        )
         if data != ""
-        else HttpResponse()
+        else HttpResponse(**kwargs)
     )
 
     response.status_code = status_code
 
     if is_browsable:
-        response = browsable_response(request, response, status_code, view)
+        response = browsable_response(request, response, status_code, view, **kwargs)
 
     return response
 

--- a/worf/urls.py
+++ b/worf/urls.py
@@ -1,0 +1,24 @@
+from types import FunctionType
+
+from django.urls import include, path
+
+
+def api(base, view, includes=[], **kwargs):
+    if isinstance(view, list):
+        return path(base, include(view), **kwargs)
+    view_class = getattr(view, "view_class", view)
+    init_kwargs = getattr(view, "view_initkwargs", {})
+    view_func = view if isinstance(view, FunctionType) else view.as_view(**init_kwargs)
+    actions = []
+    if hasattr(view_class, "perform_action"):
+        actions = [
+            path(
+                f"{action.replace('_', '-')}/",
+                view_class.as_view(action=action, **init_kwargs),
+                name=f"{kwargs['name']}_{action}" if "name" in kwargs else None,
+            )
+            for action in getattr(view_class, "actions", [])
+        ]
+    if not actions and not includes:
+        return path(base, view_func, **kwargs)
+    return path(base, include([path("", view_func, **kwargs), *includes, *actions]))


### PR DESCRIPTION
This makes it so django will miss the route entirely if the action name is invalid, and improves output on the debug 404:

<img width="326" alt="Screen Shot 2023-02-15 at 15 26 22" src="https://user-images.githubusercontent.com/289531/218960305-6f2ddcf6-6780-431f-8d85-254cf59ede21.png">

This also addresses a bug in that invalid action names currently serve a 405 for invalid action paths, and really those should be 404, but throwing a 404 from worf is not as good as making the django router miss and serve the router debug.

Also introduces an experimental `api` helper that adds sugar on top of `path` for defining api routes, meaning that ActionAPI views don't require an additional `path` reference in `urls.py`:

**Before:**

```py
path("interviews/", include([
    path("", staff.InterviewList.as_view()),
    path("<str:interview_id>/", include([
        path("", staff.InterviewDetail.as_view()),
        path("<str:action>/", staff.InterviewDetail.as_view()),
    ])),
])),
```

**After:**

```py
api("interviews/", staff.InterviewList, [
    api("<str:interview_id>/", staff.InterviewDetail),
]),
```

**TL;DR:** Actions are automatically read off of the view class and extra paths are registered for the same view, passing `action` in as an init kwarg; calling `.as_view()` is optional, if a class is supplied it will be called internally. Action paths always call it internally to pass in the `action` init kwarg.

I am still thinking about how much of a great idea this is, I've been reluctant to add this before, given urlpattern syntax is verbose because there's a lot of possibilities to cover, but ending the duplication of view references is appealing, as is registering all action paths explicitly.

This could be named `path`, and work as a drop in replacement for `django.urls` path, but that could be more confusing.