### PR TITLE
Fall back to default model ordering when no override provided in ListView

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 /coverage
 /dist
 /worf.egg-info
+__pycache__
+.idea

--- a/tests/models.py
+++ b/tests/models.py
@@ -32,13 +32,15 @@ class Profile(models.Model):
     resume = models.FileField(upload_to="resumes/", blank=True)
 
     last_active = models.DateField(blank=True, null=True)
-    created_at = models.DateTimeField(blank=True, null=True)
+    created_at = models.DateTimeField(auto_now_add=True)
 
     is_subscribed = models.BooleanField(blank=True, null=True)
     subscribed_at = models.DateTimeField(blank=True, null=True)
     subscribed_by = models.ForeignKey(
         User, blank=True, null=True, on_delete=models.SET_NULL
     )
+
+    ordering = ["-created_at"]
 
     def get_avatar_url(self):
         return self.avatar.url if self.avatar else self.get_gravatar_url()

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 from django.core.files.uploadedfile import SimpleUploadedFile
 
 from tests import parametrize
+from tests.factories import ProfileFactory
 
 
 def test_profile_detail(client, db, profile, user):
@@ -33,6 +34,19 @@ def test_profile_list(client, db, profile, user):
     assert response.status_code == 200, result
     assert len(result["profiles"]) == 1
     assert result["profiles"][0]["username"] == user.username
+
+
+def test_profile_list_default_model_ordering(client, db):
+    ProfileFactory.create_batch(3)
+    response = client.get("/profiles/")
+    result = response.json()
+    assert response.status_code == 200, result
+    assert len(result["profiles"]) == 3
+    assert (
+        result["profiles"][0]["createdAt"]
+        > result["profiles"][1]["createdAt"]
+        > result["profiles"][2]["createdAt"]
+    )
 
 
 @parametrize("page", [-1, 0, 1, 2])

--- a/tests/views.py
+++ b/tests/views.py
@@ -18,7 +18,6 @@ class ProfileList(CreateAPI, ListAPI):
         name=Concat("first_name", Value(" "), "last_name"),
         date_joined=F("user__date_joined"),
     )
-    ordering = ["pk"]
     serializer = ProfileSerializer
     permissions = [PublicEndpoint]
     search_fields = []

--- a/worf/views/list.py
+++ b/worf/views/list.py
@@ -164,7 +164,7 @@ class ListAPI(AbstractBaseAPI):
                 continue
             ordering.append(self.get_sort_field(field, descending=sort[0] == "-"))
 
-        return ordering or self.ordering
+        return ordering or self.ordering or self.model.ordering
 
     def get_sort_field(self, field, descending=False):
         return OrderBy(F(field), descending=descending)


### PR DESCRIPTION
#### What does this PR do?

Fixes a bug where a Model.ordering would not be applied if no ListView.ordering was provided.

#### What issue does this solve?

#95 

#### Where should the reviewer start?

The `test_profile_list_default_model_ordering` test provides a reproducer, while the fix is in `worf/views/list.py`

#### What Worf gif best describes this PR or how it makes you feel?

#### Checklist

- [ ] This PR increases test coverage
- [ ] This PR includes `README` updates reflecting any new features/improvements to the framework
