### PR TITLE
Support response payload serializer for views

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /dist
 /worf.egg-info
 __pycache__
+.idea

--- a/README.md
+++ b/README.md
@@ -180,6 +180,25 @@ WORF_SERIALIZER_DEFAULT_OPTIONS = {
 }
 ```
 
+Besides `serializer` attribute, `response_serializer` can be used to validate
+and serialize API responses. The example below shows 2 serializers, one for request payload
+and one for response payload.
+
+```python
+class ComputeSerializer(Serializer):
+    value = fields.Integer(required=True)
+
+
+class ComputeOutputSerializer(Serializer):
+    result = fields.Integer(required=True)
+
+class ComputeView(UpdateAPI):
+    serializer = ComputeSerializer()
+    response_serializer = ComputeOutputSerializer()
+    permissions = [PublicEndpoint]
+```
+
+
 Permissions
 -----------
 

--- a/tests/serializers.py
+++ b/tests/serializers.py
@@ -102,3 +102,11 @@ class TaskSerializer(Serializer):
 class TeamSerializer(Serializer):
     class Meta:
         fields = ["id", "name"]
+
+
+class ComputeSerializer(Serializer):
+    value = fields.Integer(required=True)
+
+
+class ComputeOutputSerializer(Serializer):
+    result = fields.Integer(required=True)

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -34,3 +34,11 @@ def test_team_serializer():
 
 def test_user_serializer():
     assert f"{tests.serializers.UserSerializer()}"
+
+
+def test_compute_serializer():
+    assert f"{tests.serializers.ComputeSerializer()}"
+
+
+def test_compute_output_serializer():
+    assert f"{tests.serializers.ComputeOutputSerializer()}"

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -507,3 +507,18 @@ def test_user_update(client, db, method, user):
     assert response.status_code == 200, result
     assert result["username"] == "testtest"
     assert result["email"] == "something@example.com"
+
+
+@parametrize(
+    "method, value, status, expected",
+    [("POST", 5, 200, 25), ("POST", 6, 200, 36), ("POST", "a", 422, None)],
+)
+def test_compute(client, db, method, value, status, expected):
+    response = client.generic(method, "/compute/", {"value": value})
+    result = response.json()
+    assert response.status_code == status, result
+    if expected:
+        assert result["result"] == expected
+
+    # Verify that output serializers exclude fields not in its schema
+    assert result.get("extra") is None

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -10,4 +10,5 @@ urlpatterns = [
     path("user/", views.UserSelf.as_view()),
     path("users/", views.UserList.as_view()),
     path("users/<int:id>/", views.UserDetail.as_view()),
+    path("compute/", views.ComputeView.as_view()),
 ]

--- a/worf/renderers.py
+++ b/worf/renderers.py
@@ -71,7 +71,11 @@ def render_response(request, data, status_code, view):
     )
 
     response = (
-        JsonResponse(data, json_dumps_params=dict(indent=2 if is_browsable else 0))
+        JsonResponse(
+            data,
+            safe=not isinstance(data, str),
+            json_dumps_params=dict(indent=2 if is_browsable else 0),
+        )
         if data != ""
         else HttpResponse()
     )

--- a/worf/serializers.py
+++ b/worf/serializers.py
@@ -2,6 +2,7 @@ import marshmallow
 from marshmallow.decorators import *  # noqa: F401, F403
 from marshmallow.utils import missing  # noqa: F401
 
+from django.core.exceptions import ImproperlyConfigured
 from django.db.models.fields.files import FieldFile
 
 from worf import fields
@@ -45,6 +46,17 @@ class SerializeModels:
 
     def serialize(self):
         return self.load_serializer().dump(self.get_instance())
+
+    def serialize_response(self, data) -> str:
+        """
+        Serialize the response if response_serializer is specified in view
+        :param data: object to be serialized by response_serializer
+        """
+        if self.response_serializer:
+            return self.response_serializer.dump(data)
+        raise ImproperlyConfigured(
+            "Response serializer is needed to serialize response data"
+        )
 
 
 class SerializerOptions(marshmallow.SchemaOpts):


### PR DESCRIPTION
#### What does this PR do?
Introducing a response payload serializer to validate and serialize response payload. 

#### What issue does this solve?

#162  Support for using separate serializers for the request and response payloads in views. This would allow us to ensure that the data is properly serialized and deserialized in both directions. When combining this feature with the no model view, we can support compute API endpoints.

#### Where should the reviewer start?
Starting at `AbstractBaseAPI` where the new attribute `response_serializer` is declared, then go to `render_to_response` method in `APIResponse` class where `response_serializer` is conditionally used if it's defined. The method `serialize_response` in `SerializeModels` is where the serialization is performed

#### What Worf gif best describes this PR or how it makes you feel?
https://i.gifer.com/HHsI.gif

#### Checklist

- [x] This PR increases test coverage
- [x] This PR includes `README` updates reflecting any new features/improvements to the framework
