### PR TITLE
(Bugfix) Fixes only and exclude nested props

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -19,8 +19,7 @@ def test_profile_detail_trimmed(client, db, profile, user):
     response = client.get(f"/profiles/trimmed/{profile.pk}/")
     result = response.json()
     assert response.status_code == 200, result
-    assert "username" not in result
-    assert result["user"]["id"] == user.id
+    assert result == dict(user=dict(id=user.id))
 
 
 def test_profile_detail_no_id(client, db, profile, user):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -15,6 +15,21 @@ def test_profile_detail(client, db, profile, user):
     assert result["username"] == user.username
 
 
+def test_profile_detail_trimmed(client, db, profile, user):
+    response = client.get(f"/profiles/trimmed/{profile.pk}/")
+    result = response.json()
+    assert response.status_code == 200, result
+    assert "username" not in result
+    assert result["user"]["id"] == user.id
+
+
+def test_profile_detail_no_id(client, db, profile, user):
+    response = client.get(f"/profiles/no-id/{profile.pk}/")
+    result = response.json()
+    assert response.status_code == 200, result
+    assert "id" not in result["user"]
+
+
 def test_profile_not_found(client, db, profile, user):
     response = client.get(f"/profiles/{uuid4()}/")
     result = response.json()

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -5,6 +5,8 @@ from tests import views
 urlpatterns = [
     path("profiles/", views.ProfileList.as_view()),
     path("profiles/<uuid:id>/", views.ProfileDetail.as_view()),
+    path("profiles/trimmed/<uuid:id>/", views.ProfileDetailTrimmed.as_view()),
+    path("profiles/no-id/<uuid:id>/", views.ProfileDetailNoID.as_view()),
     path("profiles/<uuid:id>/<str:action>/", views.ProfileDetail.as_view()),
     path("staff/<uuid:id>/", views.StaffDetail.as_view()),
     path("user/", views.UserSelf.as_view()),

--- a/tests/views.py
+++ b/tests/views.py
@@ -62,6 +62,18 @@ class ProfileDetail(ActionAPI, DeleteAPI, UpdateAPI, DetailAPI):
         return "+5555555555"
 
 
+class ProfileDetailTrimmed(ActionAPI, DeleteAPI, UpdateAPI, DetailAPI):
+    model = Profile
+    serializer = ProfileSerializer(only=["user.id"])
+    permissions = [PublicEndpoint]
+
+
+class ProfileDetailNoID(ActionAPI, DeleteAPI, UpdateAPI, DetailAPI):
+    model = Profile
+    serializer = ProfileSerializer(exclude=["user.id"])
+    permissions = [PublicEndpoint]
+
+
 class StaffDetail(ProfileDetail):
     permissions = [Authenticated, Staff]
 

--- a/worf/serializers.py
+++ b/worf/serializers.py
@@ -96,10 +96,12 @@ class Serializer(marshmallow.Schema):
     }
 
     def __init__(self, only=(), *args, **kwargs):
+        self.raw_only = only
+        self.raw_exclude = kwargs.get("exclude", None)
         super().__init__(only=only or None, *args, **kwargs)
 
     def __call__(self, **kwargs):
-        only = self.only
+        only = self.raw_only
         if self.only and kwargs.get("only"):
             invalid_fields = set(kwargs.get("only")) - self.only
             if invalid_fields:
@@ -111,7 +113,7 @@ class Serializer(marshmallow.Schema):
         return self.__class__(
             context=kwargs.get("context", self.context),
             dump_only=kwargs.get("dump_only", self.dump_only),
-            exclude=set(self.exclude or []) | set(kwargs.get("exclude") or []),
+            exclude=set(self.raw_exclude or []) | set(kwargs.get("exclude") or []),
             load_only=kwargs.get("load_only", self.load_only),
             many=kwargs.get("many", self.many),
             only=only,


### PR DESCRIPTION
#### What does this PR do?
Marshmallow pass `only` and `exclude` props through a normalizer that removes nested properties (defined in API and using the dot notation, f.e. `profile.user.id`). When we call the serializer, `only` and `exclude` are already changed, so I added a `raw_only` and `raw_exclude` to pass forward and Marshmallow can do its magic from there.

#### What Worf gif best describes this PR or how it makes you feel?
![](https://media.tenor.com/XYgm4guDJY0AAAAM/disappear-hikaru-sulu.gif)

#### Checklist

- [x] This PR increases test coverage

